### PR TITLE
Add validation check to model save

### DIFF
--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -34,6 +34,7 @@ module.exports = {
       saveOptions = {},
       preSaveAction,
       postSaveAction,
+      invalidAction,
       trackKey,
     } = options;
 
@@ -45,8 +46,18 @@ module.exports = {
       if (preSaveAction) dispatch(preSaveAction);
 
       const Model = storageManager.storage(brainstemKey).model;
-      const xhr = new Model({ id: modelId })
-        .save(attributes, saveOptions);
+      const model = new Model({ id: modelId });
+
+      if (typeof model.validate === 'function') {
+        const validationErrors = model.validate(attributes);
+
+        if (validationErrors) {
+          dispatch(invalidAction(validationErrors));
+          return validationErrors;
+        }
+      }
+
+      const xhr = model.save(attributes, saveOptions);
 
       if (postSaveAction) xhr.done(model => dispatch(postSaveAction(model.get(id))));
 

--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -48,13 +48,9 @@ module.exports = {
       const Model = storageManager.storage(brainstemKey).model;
       const model = new Model({ id: modelId });
 
-      if (typeof model.validate === 'function') {
-        const validationErrors = model.validate(attributes);
-
-        if (validationErrors) {
-          dispatch(invalidAction(validationErrors));
-          return validationErrors;
-        }
+      if (!model.isValid()) {
+        dispatch(invalidAction(model.validationError));
+        return model.validationError;
       }
 
       const xhr = model.save(attributes, saveOptions);


### PR DESCRIPTION
Since Backbone models don't come with validators, we can't assume that they exist. The Backbone API assumes that the validator method will return nothing if the model is valid, and an object with the errors if the model is invalid.