### PR TITLE
Handle store updates when `entity` is not passed.

### DIFF
--- a/lib/sync/update-store.js
+++ b/lib/sync/update-store.js
@@ -6,9 +6,7 @@ module.exports = (store) => {
       if (eventName.indexOf(':') > -1) return;
 
       // Heuristic for the time being
-      if (entity !== undefined
-          && typeof entity.attributes === 'object'
-          && entity.attributes) {
+      if (entity !== undefined && entity.attributes) {
         store.dispatch({
           type: `${eventName.toUpperCase()}_MODEL`,
           payload: {

--- a/lib/sync/update-store.js
+++ b/lib/sync/update-store.js
@@ -6,7 +6,9 @@ module.exports = (store) => {
       if (eventName.indexOf(':') > -1) return;
 
       // Heuristic for the time being
-      if (entity.attributes) {
+      if (entity !== undefined
+          && typeof entity.attributes === 'object'
+          && entity.attributes) {
         store.dispatch({
           type: `${eventName.toUpperCase()}_MODEL`,
           payload: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "scripts": {

--- a/spec/sync/update-store-spec.js
+++ b/spec/sync/update-store-spec.js
@@ -22,4 +22,8 @@ describe('handling events from storageManager', () => {
 
     expect(this.store.getState().brainstem.posts).toEqual({});
   });
+
+  it('does not throw an exception when the entity is not passed', function () {
+    expect(() => { this.posts.add(); }).not.toThrow();
+  });
 });

--- a/spec/sync/update-store-spec.js
+++ b/spec/sync/update-store-spec.js
@@ -23,7 +23,7 @@ describe('handling events from storageManager', () => {
     expect(this.store.getState().brainstem.posts).toEqual({});
   });
 
-  it('does not throw an exception when the entity is not passed', function () {
-    expect(() => { this.posts.add(); }).not.toThrow();
+  it('does not throw an exception when the entity is not passed to the model', function () {
+    expect(() => { this.posts.first().trigger('some-random-event'); }).not.toThrow();
   });
 });


### PR DESCRIPTION
Do not blow up when updating with a key and not attributes.

Fixes: https://www.pivotaltracker.com/story/show/133377475