### PR TITLE
Fix post-save callback for when model is new and doesn't have id yet

### DIFF
--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -49,7 +49,12 @@ module.exports = {
       const xhr = new Model({ id: modelId })
         .save(attributes, saveOptions);
 
-      if (postSaveAction) xhr.done(model => dispatch(postSaveAction(model.get('id'))));
+      if (postSaveAction) {
+        xhr.done((results) => {
+          const newModelId = results.result[0].id;
+          dispatch(postSaveAction(newModelId));
+        });
+      }
 
       if (trackKey) xhrs[trackKey] = xhr;
 


### PR DESCRIPTION
Fix post-save callback for when model is new and doesn't have id yet