### PR TITLE
Bump BrainstemJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "brainstem-js": "^0.4.10",
+    "brainstem-js": "^0.4.12",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0"
   },


### PR DESCRIPTION
Keep at version parity with mavenlink-js for flatter module folder structure when libraries use both