### PR TITLE
Bump the brainstem version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "brainstem-js": "^0.4.25",
+    "brainstem-js": "^0.4.28",
     "jquery": "2.2.4",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0"


### PR DESCRIPTION
Includes a fix for outputting errors with the correct collection name: [brainstem-js/pull/106](https://github.com/mavenlink/brainstem-js/pull/106)