### PR TITLE
Add set model action

### DIFF
--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -108,4 +108,11 @@ module.exports = {
       return validationErrors;
     };
   },
+
+  set(model, ...args) {
+    return () => {
+      model.set(...args);
+      return $.Deferred().resolve().promise(); // eslint-disable-line new-cap
+    };
+  },
 };

--- a/spec/actions/model-spec.js
+++ b/spec/actions/model-spec.js
@@ -129,4 +129,36 @@ describe('model action creators', () => {
       expect(xhr.fail).toEqual(jasmine.any(Function));
     });
   });
+
+  describe('set', () => {
+    beforeEach(function () {
+      this.model = { set: jasmine.createSpy('set') };
+    });
+
+    it('returns a resolved promise', function () {
+      const doneAction = jasmine.createSpy('doneAction');
+
+      const result = this.store.dispatch(modelActions.set(this.model, 'foo', 'bar')).done(doneAction);
+
+      expect(doneAction).toHaveBeenCalled();
+      expect(result.resolve).toBeUndefined();
+      expect(result.reject).toBeUndefined();
+    });
+
+    describe('when the attribute and value are passed separately', () => {
+      it('calls set on the passed object with the passed attribute and value when dispatched', function () {
+        this.store.dispatch(modelActions.set(this.model, 'foo', 'bar'));
+        expect(this.model.set).toHaveBeenCalledWith('foo', 'bar');
+        expect(this.model.set).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when the attribute and value are passed as an object', () => {
+      it('calls set on the passed object with the argument when dispatched', function () {
+        this.store.dispatch(modelActions.set(this.model, { foo: 'bar' }));
+        expect(this.model.set).toHaveBeenCalledWith({ foo: 'bar' });
+        expect(this.model.set).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Takes model, attribute, and value, or attribute and value in object.
  Returns a function that calls set on the model passing args.
- Returned function returns a resolved promise when called.

This was suggested as a generalization of work done here: https://github.com/mavenlink/mavenlink/pull/8618