### PR TITLE
Correct README's create model example to reference `null`id

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ modelActions.fetch('posts', 42, {
 ```
 const { modelActions } = require('brainstem-redux')
 
-modelActions.save('posts', 42, {
+modelActions.save('posts', null, {
   title: 'New post'
 })
 ```


### PR DESCRIPTION
Aren't you supposed to pass in `null` for the modelId if you're using the `save` function for create rather than update?