### PR TITLE
Implement promise interface for collection fetch action thunk

### DIFF
--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -25,12 +25,10 @@ module.exports = {
 
       if (trackKey) xhrs[trackKey] = xhr;
 
-      const promise = new Promise((resolve, reject) => xhr
+      return new Promise((resolve, reject) => xhr
         .done(collection => resolve(collection.map(model => model.attributes)))
         .fail(reject)
       );
-
-      return promise;
     };
   },
 };

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -25,7 +25,12 @@ module.exports = {
 
       if (trackKey) xhrs[trackKey] = xhr;
 
-      return xhr;
+      const promise = new Promise((resolve, reject) => {
+        xhr.done(collection => resolve(collection.map(model => model.attributes)));
+        xhr.fail(reject);
+      });
+
+      return promise;
     };
   },
 };

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -25,10 +25,10 @@ module.exports = {
 
       if (trackKey) xhrs[trackKey] = xhr;
 
-      const promise = new Promise((resolve, reject) => {
-        xhr.done(collection => resolve(collection.map(model => model.attributes)));
-        xhr.fail(reject);
-      });
+      const promise = new Promise((resolve, reject) => xhr
+        .done(collection => resolve(collection.map(model => model.attributes)))
+        .fail(reject)
+      );
 
       return promise;
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.25-0",
+  "version": "0.0.25",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.24-0",
+  "version": "0.0.25-0",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.23",
+  "version": "0.0.24-0",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "scripts": {

--- a/spec/actions/collection-spec.js
+++ b/spec/actions/collection-spec.js
@@ -1,5 +1,7 @@
+const $ = require('jquery');
 const beforeEachHelpers = require('../helpers/before-each');
 const collectionActions = require('../../lib/actions/collection');
+const Post = require('../../example/models/post');
 
 describe('collection action creators', () => {
   beforeEach(function () {
@@ -17,13 +19,41 @@ describe('collection action creators', () => {
     expect(expectation.requestQueue.length).toBe(1);
   });
 
+  describe('promise interface', () => {
+    it('exists', function () {
+      this.storageManager.stub('posts');
+      expect(this.store.dispatch(this.fetch('posts'))).toEqual(jasmine.any(Promise));
+    });
+
+    it('resolves with raw attributes when jqXHR is done', function (done) {
+      const postsModels = [new Post({ id: 1, title: 'Bar' }), new Post({ id: 2, title: 'Foo' })];
+      const expectation = this.storageManager.stub('posts', {
+        response(responseBody) {
+          responseBody.results = postsModels; // eslint-disable-line no-param-reassign
+        },
+      });
+      this.store.dispatch(this.fetch('posts')).then((response) => {
+        expect(response).toEqual(postsModels.map(model => model.attributes));
+        done();
+      });
+      expectation.respond();
+    });
+
+    it('rejects when jqXHR fails', function (done) {
+      const deferred = $.Deferred(); // eslint-disable-line new-cap
+      spyOn(this.storageManager.storage('posts'), 'fetch').and.returnValue(deferred);
+      this.store.dispatch(this.fetch('posts')).catch(done);
+      deferred.reject();
+    });
+  });
+
   describe('previous XHRs', () => {
     it('uses a trackKey to abort previous pending XHR', function () {
       const abort = jasmine.createSpy('abort');
       const state = () => 'pending';
       spyOn(this.storageManager.storage('posts'), 'fetch').and.returnValue({ abort, state });
-      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' }));
-      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' }));
+      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
+      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
 
       expect(abort).toHaveBeenCalledTimes(1);
     });
@@ -32,8 +62,8 @@ describe('collection action creators', () => {
       const abort = jasmine.createSpy('abort');
       const state = () => 'resolved';
       spyOn(this.storageManager.storage('posts'), 'fetch').and.returnValue({ abort, state });
-      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' }));
-      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' }));
+      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
+      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
 
       expect(abort).toHaveBeenCalledTimes(0);
     });


### PR DESCRIPTION
Fulfilling promises with raw model attribute data facilitates backbone avoidance in connected components.

This is an effort in sun-setting `postFetchAction`:

- Callback option should be a more readable async pattern (which I think Promises alleviate)
- Callback is resolved with just IDs but there are some scenarios when the whole model needs to be accessed (like looking up association data for the action to be dispatched once the request is resolved)

See issue @ https://github.com/mavenlink/brainstem-redux/issues/4