### PR TITLE
Add repository link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
       "email": "bduff@mavenlink.com"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mavenlink/brainstem-redux.git"
+  },
   "license": "MIT",
   "dependencies": {
     "brainstem-js": "^0.4.30",


### PR DESCRIPTION
This adds a link to the GitHub repo for the project to `package.json`.  That allows people to get from the [npm package page](https://www.npmjs.com/package/brainstem-redux) to the GitHub repo.