### PR TITLE
Add make-brainstem-type which provides utilities for working with models

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   - Model fetching
   - Model saving
   - Collection fetching
+- Provides a "type creator" that provides functions for working with models and collections
 
 [![npm version](https://img.shields.io/npm/v/brainstem-redux.svg?style=flat-square)](https://www.npmjs.com/package/brainstem-redux)
 [![npm downloads](https://img.shields.io/npm/dm/brainstem-redux.svg?style=flat-square)](https://www.npmjs.com/package/brainstem-redux)
@@ -21,7 +22,7 @@
 2. When you create your store, apply the `updateStorageManager` middleware (syncs store -> storage manager)
 3. Finally, set up event handlers to sync the storage manager -> store
 
-```
+```js
 const {
   reducer: brainstemReducer,
   updateStore,
@@ -51,6 +52,297 @@ const store = createStore(appReducer, storeMiddleware)
 require('lib/sync/update-store')(store);
 ```
 
+### Create Brainstem-redux type objects
+
+A "type" is a family of functions that operate on objects with a given shape.  In the case of this library, the objects will be the models and collections in the store.
+
+Brainstem-redux provides `makeBrainstemType`, a factory function that returns an object containing a set of handy functions for working with your models and collections.
+
+#### Creating a Type
+
+To create a type, use `makeBrainstemType`:
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+module.exports = makeBrainstemType('posts');
+```
+
+If you want to add some of your own application-specific type functions, you can merge your functions using `Object.assign` or similar function:
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+function doSomethingWithPost(post) {
+  // ...
+}
+
+module.exports = Object.assign({},
+  makeBrainstemType('posts'),
+  {
+    doSomethingWithPost,
+  },
+);
+```
+
+`makeBrainstemType` also takes an optional `filter` argument that allows you to return only a subset of the models in a collection:
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+module.exports = makeBrainstemType('posts', post => !post.published);
+```
+
+#### Using a Type
+
+Once you've defined your type, you can use its functions in your application.
+
+**Action Creators**
+
+`makeBrainstemType` provides action creators that wrap the `modelActions` and `collectionActions` discussed below.
+
+- `fetchAll(options)`
+
+Fetch a collection (wraps `collectionActions.fetch`).
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Post = makeBrainstemType('posts');
+
+Post.fetchAll({
+  fetchOptions: {
+    include: ['subject']
+  }
+});
+```
+
+- `fetch(id, options)`
+
+Fetch a model (wraps `modelActions.fetch`).
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Post = makeBrainstemType('posts');
+
+Post.fetch(42, {
+  fetchOptions: {
+    include: ['subject']
+  }
+});
+```
+
+- `save(id, options)`
+
+Save a model (wraps `modelActions.save`)
+
+Creating a new model:
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Post = makeBrainstemType('posts');
+
+Post.save(null, {
+  title: 'New post'
+});
+```
+
+Updating an existing model:
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Post = makeBrainstemType('posts');
+
+Post.save(42, {
+  title: 'Update post'
+});
+```
+
+- `destroy(id)`
+
+Destroy a model (wraps `modelActions.destroy`).
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Post = makeBrainstemType('posts');
+
+Post.destroy(42);
+```
+
+**Selectors**
+
+`makeBrainstemType` provides a number of [selectors](https://stackoverflow.com/a/38674427) for looking up models.
+
+- `all(state)`
+
+Get a lookup table of all objects.
+
+**NOTE:** This will return all of the models in the Brainstem storage manager, so this should only be used as a lookup table when looking up associated objects, and not as the list of objects you need to display; rather, you should store a list of IDs in your state tree and use `findAll` or `findAllInState` to find the objects matching those IDs.
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const User = makeBrainstemType('users');
+
+function author(users, post) {
+  return User.find(post.author_id, users);
+}
+
+const Post = Object.assign({},
+  makeBrainstemType('posts'),
+  {
+    author
+  }
+);
+
+// Elsewhere:
+const post = Post.findInState(42, state);
+const author = Post.author(User.all(state), post);
+```
+
+- `find(id, collection)`
+
+Finds a model by its ID in a lookup object (such as that returned by `all`).
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const User = makeBrainstemType('users');
+
+function author(users, post) {
+  return User.find(post.author_id, users);
+}
+
+// Elsewhere:
+const author = Post.author(User.all(state), post);
+```
+
+- `findAll(ids, collection)`
+
+Finds a list of models by their IDs in a lookup object (such as that returned by `all`).
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Tag = makeBrainstemType('tags');
+
+function tags(allTags, post) {
+  return Tag.findAll(post.tag_ids, allTags);
+}
+
+// Elsewhere:
+const author = Post.tags(Tag.all(state), post);
+```
+
+- `findInState(id, state)`
+
+Finds a model by its ID in the Redux state tree.  Assumes that the Brainstem data is at `state.brainstem`.
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Post = makeBrainstemType('posts');
+
+Post.findInState(42, state);
+```
+
+- `findAllInState(ids, state)`
+
+Finds a list of models by their IDs in the Redux state tree.
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Post = makeBrainstemType('posts');
+
+Post.findAllInState(state.myApp.postIds, state);
+```
+
+- `findInList(id, list)`
+
+Finds a model by its ID in a list of models.
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Post = makeBrainstemType('posts');
+
+const posts = Post.findAllInState(state.myApp.postIds, state);
+const selectedPost = Post.findInList(state.myApp.selectedPostId, posts);
+```
+
+**Reducer Helper**
+
+Sometimes, you'd like to have one of your application's reducers respond to an action generated by Brainstem-redux (such as `SYNC_MODEL` or `REMOVE_MODEL`, for example).
+
+In order to make it easier to determine if the action is appropriate for the model you're working with, you can use `matchesAction` in your reducer.
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+
+const Post = makeBrainstemType('posts');
+
+function reducer(state, action) {
+  switch (action.type) {
+    case: 'SYNC_MODEL':
+      return Post.matchesAction(action) : doSomething(state, action) : state;
+    // ...
+    default:
+      return state;
+  }
+}
+```
+
+**Test Helpers**
+
+In order to test reducers that respond to Brainstem-redux actions, you need to be able to create actions that match what Brainstem-redux creates.
+
+- `removeModel(model)`
+
+Creates a properly-formed `REMOVE_MODEL` action.
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+const reducer = require('./reducer');
+
+const Post = makeBrainstemType('posts');
+
+describe('My reducer', () => {
+  it('removes a model', () => {
+    const post = { id: '42', title: 'A Post' };
+    const initialState = { postIds: ['42', '58'] };
+    const action = Post.removeModel(post);
+    const newState = reducer(initialState, action);
+
+    expect(newState).toEqual(['58']);
+  });
+});
+```
+
+- `syncModel(model)`
+
+Creates a properly-formed `SYNC_MODEL` action.
+
+```js
+const { makeBrainstemType } = require('brainstem-redux');
+const reducer = require('./reducer');
+
+const Post = makeBrainstemType('posts');
+
+describe('My reducer', () => {
+  it('removes a model', () => {
+    const post = { id: '42', title: 'A Post' };
+    const initialState = { postIds: ['58'] };
+    const action = Post.syncModel(post);
+    const newState = reducer(initialState, action);
+
+    expect(newState).toEqual(['58', '42']);
+  });
+});
+```
+
 ### Use Brainstem-redux action creators
 
 When you want to fetch, save, or destroy your models or fetch your collections, use the `modelActions` and `collectionActions` to make sure both your store and storage manager get updated. These action creators feature a few things to facilitate most common usages of fetch / save / destroy.
@@ -64,7 +356,7 @@ Each action creator takes an object of options.
 
 * Fetch a model
 
-```
+```js
 const { modelActions } = require('brainstem-redux')
 
 modelActions.fetch('posts', 42, {
@@ -76,7 +368,7 @@ modelActions.fetch('posts', 42, {
 
 * Save a model (create)
 
-```
+```js
 const { modelActions } = require('brainstem-redux')
 
 modelActions.save('posts', null, {
@@ -88,7 +380,7 @@ modelActions.save('posts', null, {
   * Note that `update` creates a new Brainstem model and will not make a request if the model is [invalid](https://github.com/mavenlink/brainstem-redux/blob/master/lib/actions/model.js#L53-L58). Adding a reject handler addresses this locally.
 
 
-```
+```js
 const { modelActions } = require('brainstem-redux')
 
 modelActions.save('posts', 42, {
@@ -98,7 +390,7 @@ modelActions.save('posts', 42, {
 
 * Destroy a model
 
-```
+```js
 const { modelActions } = require('brainstem-redux')
 
 modelActions.destroy('posts', 42)
@@ -106,10 +398,10 @@ modelActions.destroy('posts', 42)
 
 * Fetch a collection
 
-```
+```js
 const { collectionActions } = require('brainstem-redux')
 
-modelActions.fetch('posts', {
+collectionActions.fetch('posts', {
   fetchOptions: {
     include: ['subject']
   }
@@ -123,8 +415,10 @@ modelActions.fetch('posts', {
 2. `updateStore`: event handling of all the collections in your storage manager; dispatches the appropriate actions to the redux store
 3. `stopUpdateStore`: helper function to stop updating your redux store from your storage manager; invoke with your redux store as the first argument (useful for test cleanup)
 4. `updateStorageManager`: *middleware* that syncs the redux store with your storage manager
-5. `modelActions`: action creators for your models
-6. `collectionActions`: action creators for your collections
+5. `makeBrainstemType`: creates a set of action creators, selectors, and reducer helpers to work with your models
+6. `modelActions`: action creators for your models
+7. `collectionActions`: action creators for your collections
 
 ## Local Development
+
 In order to develop against a local checkout, run `yarn link` in `brainstem-redux`, then `yarn link brainstem-redux` in the project you want to use it in and restart webpack. Also, make sure to `yarn compile` when making changes in `brainstem-redux`.

--- a/api.js
+++ b/api.js
@@ -1,6 +1,7 @@
 const reducer = require('./lib/reducers');
 const updateStore = require('./lib/sync/update-store');
 const updateStorageManager = require('./lib/middleware/update-storage-manager');
+const makeBrainstemType = require('./lib/types/make-brainstem-type');
 const modelActions = require('./lib/actions/model');
 const collectionActions = require('./lib/actions/collection');
 const stopUpdateStore = require('./lib/sync/stop-update-store');
@@ -9,6 +10,7 @@ module.exports = {
   reducer,
   updateStore,
   updateStorageManager,
+  makeBrainstemType,
   modelActions,
   collectionActions,
   stopUpdateStore,

--- a/karma.config.js
+++ b/karma.config.js
@@ -1,12 +1,17 @@
 const webpackConfig = require('./webpack.config');
 
 
-const karmaWebpackLoadersOverrides = [{
-  query: {
-    presets: ['es2015'],
-    plugins: ['transform-runtime'],
+const karmaWebpackLoadersOverrides = [
+  {
+    query: {
+      presets: ['es2015'],
+      plugins: [
+        'transform-runtime',
+        ['transform-object-rest-spread', { useBuiltIns: true }],
+      ],
+    },
   },
-}];
+];
 const karmaWebpackLoaders = webpackConfig.module.loaders
   .map((loader, i) => Object.assign({}, loader, karmaWebpackLoadersOverrides[i]));
 const karmaWebpackConfig = Object.assign({}, webpackConfig, {

--- a/karma.config.js
+++ b/karma.config.js
@@ -35,6 +35,7 @@ module.exports = config =>
       'spec/reducers/*.js',
       'spec/middleware/*.js',
       'spec/sync/*.js',
+      'spec/types/*.js',
       'spec/api-spec.js',
     ],
 

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -1,0 +1,89 @@
+const lodashFind = require('lodash.find');
+const isObject = require('lodash.isobject');
+const pickBy = require('lodash.pickby');
+const collectionActions = require('../actions/collection');
+const modelActions = require('../actions/model');
+
+module.exports = function makeBrainstemType(brainstemKey, filter = () => true) {
+  function all(state) {
+    return pickBy(state.brainstem[brainstemKey], filter);
+  }
+
+  function find(id, models) {
+    return models[id];
+  }
+
+  function findAll(idList, models) {
+    return idList.map(id => find(id, models));
+  }
+
+  function findAllInState(idList, state) {
+    return findAll(idList, all(state));
+  }
+
+  function findInList(id, list) {
+    return lodashFind(list, model => model.id === id);
+  }
+
+  function findInState(id, state) {
+    return find(id, all(state));
+  }
+
+  function fetchAll(options) {
+    return collectionActions.fetch(brainstemKey, options);
+  }
+
+  function fetch(id, options) {
+    return modelActions.fetch(brainstemKey, id, options);
+  }
+
+  function save(id, attributes, options) {
+    return modelActions.save(brainstemKey, id, attributes, options);
+  }
+
+  function destroy(id, options) {
+    return modelActions.destroy(brainstemKey, id, options);
+  }
+
+  function matchesAction({ meta, payload }) {
+    return (
+      isObject(meta) && meta.origin === 'storageManager' &&
+      isObject(payload) && payload.brainstemKey === brainstemKey
+    );
+  }
+
+  function modelAction(type, model) {
+    return {
+      type,
+      meta: { origin: 'storageManager' },
+      payload: {
+        brainstemKey,
+        attributes: model,
+      },
+    };
+  }
+
+  function removeModel(model) {
+    return modelAction('REMOVE_MODEL', model);
+  }
+
+  function syncModel(model) {
+    return modelAction('SYNC_MODEL', model);
+  }
+
+  return {
+    all,
+    destroy,
+    find,
+    findAll,
+    findAllInState,
+    findInList,
+    findInState,
+    fetchAll,
+    fetch,
+    matchesAction,
+    removeModel,
+    save,
+    syncModel,
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.27",
+  "version": "0.0.28-alpha",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.28-alpha",
+  "version": "0.0.28-alpha.1",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
   "dependencies": {
     "brainstem-js": "^0.4.30",
     "jquery": "2.2.4",
+    "lodash.find": "^4.6.0",
+    "lodash.isobject": "^3.0.2",
+    "lodash.omit": "^4.5.0",
+    "lodash.pickby": "^4.6.0",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "babel-core": "^6.18.0",
     "babel-loader": "^6.2.5",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.18.0",
     "eslint": "^3.8.1",

--- a/spec/api-spec.js
+++ b/spec/api-spec.js
@@ -6,6 +6,7 @@ describe('API', () => {
     expect(typeof index.updateStore).toEqual('function');
     expect(typeof index.updateStorageManager).toEqual('function');
     expect(typeof index.stopUpdateStore).toEqual('function');
+    expect(typeof index.makeBrainstemType).toEqual('function');
     expect(index.modelActions).toBeDefined();
     expect(index.collectionActions).toBeDefined();
   });

--- a/spec/types/make-brainstem-type-spec.js
+++ b/spec/types/make-brainstem-type-spec.js
@@ -1,0 +1,212 @@
+const omit = require('lodash.omit');
+const collectionActions = require('../../lib/actions/collection');
+const modelActions = require('../../lib/actions/model');
+const makeBrainstemType = require('../../lib/types/make-brainstem-type');
+
+describe('makeBrainstemType', () => {
+  const brainstemKey = 'KEY';
+  const type = makeBrainstemType(brainstemKey);
+
+  describe('looking up models', () => {
+    const model1 = { id: '5' };
+    const model2 = { id: '11' };
+    const model3 = { id: '42' };
+    const models = {
+      [model1.id]: model1,
+      [model2.id]: model2,
+      [model3.id]: model3,
+    };
+    const state = {
+      brainstem: { [brainstemKey]: models },
+    };
+
+    describe('looking up all models in the state', () => {
+      it('returns all models in the state tree', () => {
+        expect(type.all(state)).toEqual(models);
+      });
+    });
+
+    describe('finding a model by id', () => {
+      describe('when the model is present', () => {
+        const id = model2.id;
+
+        it('returns the model', () => {
+          expect(type.find(id, models)).toEqual(model2);
+        });
+      });
+
+      describe('when the model is not present', () => {
+        const id = 'MISSING';
+
+        it('returns undefined', () => {
+          expect(type.find(id, models)).toBeUndefined();
+        });
+      });
+    });
+
+    describe('finding a model by id in the state', () => {
+      const id = model3.id;
+
+      it('returns the model', () => {
+        expect(type.findInState(id, state)).toEqual(model3);
+      });
+    });
+
+    describe('finding a model by id in a list', () => {
+      const modelList = [model1, model2, model3];
+
+      describe('when the model is present', () => {
+        const id = model2.id;
+
+        it('returns the model', () => {
+          expect(type.findInList(id, modelList)).toEqual(model2);
+        });
+      });
+
+      describe('when the model is not present', () => {
+        const id = 'MISSING';
+
+        it('returns undefined', () => {
+          expect(type.findInList(id, modelList)).toBeUndefined();
+        });
+      });
+    });
+
+    describe('finding a list of models by id', () => {
+      describe('when all models are present', () => {
+        const idList = [model3.id, model1.id];
+
+        it('returns all found models in the order specified', () => {
+          expect(type.findAll(idList, models)).toEqual([model3, model1]);
+        });
+      });
+
+      describe('when some models are missing', () => {
+        const idList = ['MISSING', model2.id];
+
+        it('returns undefined for missing models', () => {
+          expect(type.findAll(idList, models)).toEqual([undefined, model2]);
+        });
+      });
+    });
+
+    describe('finding a list of models by id in the state', () => {
+      const idList = [model2.id, model3.id];
+
+      it('returns all found models in the order specified', () => {
+        expect(type.findAllInState(idList, state)).toEqual([model2, model3]);
+      });
+    });
+  });
+
+  describe('fetching a collection of models', () => {
+    beforeEach(() => {
+      spyOn(collectionActions, 'fetch').and.returnValue('RESULT');
+    });
+
+    it('forwards the request to brainstem-redux', () => {
+      const options = 'OPTIONS';
+      expect(type.fetchAll(options)).toEqual('RESULT');
+      expect(collectionActions.fetch).toHaveBeenCalledWith(brainstemKey, options);
+    });
+  });
+
+  describe('fetching a model by id', () => {
+    beforeEach(() => {
+      spyOn(modelActions, 'fetch').and.returnValue('RESULT');
+    });
+
+    it('forwards the request to brainstem-redux', () => {
+      const id = '2';
+      const options = 'OPTIONS';
+      expect(type.fetch(id, options)).toEqual('RESULT');
+      expect(modelActions.fetch).toHaveBeenCalledWith(brainstemKey, id, options);
+    });
+  });
+
+  describe('saving a model', () => {
+    beforeEach(() => {
+      spyOn(modelActions, 'save').and.returnValue('RESULT');
+    });
+
+    it('forwards the request to brainstem-redux', () => {
+      const id = '2';
+      const attributes = 'ATTRIBUTES';
+      const options = 'OPTIONS';
+      expect(type.save(id, attributes, options)).toEqual('RESULT');
+      expect(modelActions.save).toHaveBeenCalledWith(brainstemKey, id, attributes, options);
+    });
+  });
+
+  describe('deleting a model', () => {
+    beforeEach(() => {
+      spyOn(modelActions, 'destroy').and.returnValue('RESULT');
+    });
+
+    it('forwards the request to brainstem-redux', () => {
+      const id = '2';
+      const options = 'OPTIONS';
+      expect(type.destroy(id, options)).toEqual('RESULT');
+      expect(modelActions.destroy).toHaveBeenCalledWith(brainstemKey, id, options);
+    });
+  });
+
+  describe('matching actions from brainstem-redux', () => {
+    const modelAction = type.syncModel({ id: '1' });
+
+    function itDoesNotMatch(action) {
+      expect(type.matchesAction(action)).toEqual(false);
+    }
+
+    describe('when the origin and key match', () => {
+      const action = modelAction;
+
+      it('matches', () => {
+        expect(type.matchesAction(action)).toEqual(true);
+      });
+    });
+
+    describe('when the origin is not the brainstem storage manager', () => {
+      const action = {
+        ...modelAction,
+        meta: { origin: 'OTHER' },
+      };
+
+      it('does not match', () => {
+        itDoesNotMatch(action);
+      });
+    });
+
+    describe('when the origin is missing', () => {
+      const action = omit(modelAction, 'meta');
+
+      it('does not match', () => {
+        itDoesNotMatch(action);
+      });
+    });
+
+    describe('when the action is for a different model', () => {
+      const action = { ...modelAction, payload: { brainstemKey: 'OTHER_KEY' } };
+
+      it('does not match', () => {
+        itDoesNotMatch(action);
+      });
+    });
+
+    describe('when there is no brainstem key', () => {
+      const action = { ...modelAction, payload: {} };
+
+      it('does not match', () => {
+        itDoesNotMatch(action);
+      });
+    });
+
+    describe('when there is no payload', () => {
+      const action = omit(modelAction, 'payload');
+
+      it('does not match', () => {
+        itDoesNotMatch(action);
+      });
+    });
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,9 @@ module.exports = {
       loader: 'babel-loader',
       query: {
         presets: ['es2015'],
+        plugins: [
+          ['transform-object-rest-spread', { useBuiltIns: true }],
+        ],
       },
     }],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,6 +328,10 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
@@ -496,6 +500,13 @@ babel-plugin-transform-es2015-unicode-regex@^6.24.1:
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
+
 babel-plugin-transform-regenerator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
@@ -556,7 +567,14 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
+babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -3104,6 +3122,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regenerator-transform@0.9.11:
   version "0.9.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2448,13 +2448,25 @@ lodash.endswith@^4.0.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.endswith/-/lodash.endswith-4.2.1.tgz#fed59ac1738ed3e236edd7064ec456448b37bc09"
 
-lodash.find@^4.3.0:
+lodash.find@^4.3.0, lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
 
 lodash.findindex@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.findindex/-/lodash.findindex-4.6.0.tgz#a3245dee61fb9b6e0624b535125624bb69c11106"
+
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+
+lodash.pickby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
 lodash@^3.8.0:
   version "3.10.1"


### PR DESCRIPTION
This PR adds `makeBrainstemType`, a factory function that creates a number of functions to work with a Brainstem model in the context of a Redux application.

Call it with the key of the Brainstem collection: `makeBrainstemType('collection-name')`.

The returned object contains a number of functions:

Async actions:
- fetchAll: wraps `collectionActions.fetch`
- fetch: wraps `modelActions.fetch`
- save: wraps `modelActions.save`
- destroy: wraps `modelActions.destroy`

Selectors:
- all: returns a lookup object containing all of the models in your collection
- find: finds a model by its ID in a lookup object
- findAll: finds a list of models by their IDs in a lookup object
- findAllInState: finds a list of models by their ID in the Redux state tree
- findInList: finds a model by its ID in a list of models
- findInState: finds a model by its ID in the Redux state tree

Reducer helper:
- matchesAction: determines if a Redux action is a brainstem-redux action for your collection/model type

Test helpers:
- removeModel: creates a properly formed `REMOVE_MODEL` action for your model type
- syncModel: creates a properly formed `SYNC_MODEL` action for your model type
