### PR TITLE
Omit unnecessary files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.27",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
+  "files": [
+    "bin/index.js"
+  ],
   "scripts": {
     "ci:lint": "yarn lint",
     "ci:test": "yarn karma -- --single-run",


### PR DESCRIPTION
Our current npm package includes all of the files in the repo, including the entire `lib` directory, `yarn.lock`, and `.idea` directory, among others.

This PR reduces it down to the bare minimum: the compiled package, the README, and the `package.json` file.

Before:

```
$ ls -l brainstem-redux-0.0.27.tgz
-rw-r--r--  1 mavenlink  staff  124434 Aug 31 15:58 brainstem-redux-0.0.27.tgz
$ tar tzf brainstem-redux-0.0.27.tgz
package/package.json
package/.npmignore
package/README.md
package/api.js
package/.eslintrc.js
package/karma.config.js
package/webpack.config.js
package/.eslintignore
package/lib/actions/collection.js
package/lib/actions/model.js
package/lib/helpers/storage-manager-collection-iterator.js
package/lib/middleware/update-storage-manager.js
package/lib/reducers/index.js
package/lib/reducers/initial-state.js
package/lib/reducers/remove-model.js
package/lib/reducers/update-model.js
package/lib/state-shape.md
package/lib/sync/stop-update-store.js
package/lib/sync/storage-manager-listener.js
package/lib/sync/update-store.js
package/bin/index.js
package/circle.yml
package/yarn.lock
```

After:

```
$ ls -l brainstem-redux-0.0.27.tgz
-rw-r--r--  1 mavenlink  staff  83284 Aug 31 16:36 brainstem-redux-0.0.27.tgz
$ tar tzf brainstem-redux-0.0.27.tgz
package/package.json
package/README.md
package/bin/index.js
```
