### PR TITLE
Move brainstem-js, jquery, redux, redux-thunk as peer dependencies (i…

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "url": "https://github.com/mavenlink/brainstem-redux.git"
   },
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "brainstem-js": "^0.4.30",
     "jquery": "2.2.4",
     "redux": "^3.5.2",


### PR DESCRIPTION
…nstead of dependencies)

Assumes host module sets up these dependencies.