### PR TITLE
Skip syncBrainstem when state.brainstem does not change

### DIFF
--- a/lib/middleware/update-storage-manager.js
+++ b/lib/middleware/update-storage-manager.js
@@ -28,10 +28,13 @@ function syncBrainstem(store) {
 }
 
 module.exports = store => next => (action) => {
+  const previousState = store.getState();
   const result = next(action);
+  const currentState = store.getState();
 
   if (action.meta && action.meta.origin === 'storageManager') return result;
-  if (action.meta && action.meta.skipSyncBrainstem) return result;
+  if (previousState.brainstem === currentState.brainstem) return result;
+
   syncBrainstem(store);
   return result;
 };

--- a/lib/middleware/update-storage-manager.js
+++ b/lib/middleware/update-storage-manager.js
@@ -31,7 +31,7 @@ module.exports = store => next => (action) => {
   const result = next(action);
 
   if (action.meta && action.meta.origin === 'storageManager') return result;
-
+  if (action.meta && action.meta.skipSyncBrainstem) return result;
   syncBrainstem(store);
   return result;
 };

--- a/spec/middleware/sync-storage-manager-spec.js
+++ b/spec/middleware/sync-storage-manager-spec.js
@@ -48,4 +48,21 @@ describe('sync-brainstem middleware', () => {
 
     expect(this.posts.get(76)).not.toBeDefined();
   });
+
+  describe('when skipSyncBrainstem is true', () => {
+    it('does not synce with the storageManager', function () {
+      this.store.dispatch({
+        type: 'REMOVE_MODEL',
+        payload: {
+          brainstemKey: 'posts',
+          attributes: { id: 76 },
+        },
+        meta: {
+          skipSyncBrainstem: true,
+        },
+      });
+
+      expect(this.posts.get(76)).toBeDefined();
+    });
+  });
 });

--- a/spec/middleware/sync-storage-manager-spec.js
+++ b/spec/middleware/sync-storage-manager-spec.js
@@ -1,8 +1,6 @@
 const beforeEachHelpers = require('../helpers/before-each');
 
 describe('sync-brainstem middleware', () => {
-  const extractArgsFromCalls = method => method.calls.all().map(call => call.args[0]);
-
   beforeEach(function () {
     beforeEachHelpers.call(this);
     this.posts = this.storageManager.storage('posts');
@@ -62,8 +60,8 @@ describe('sync-brainstem middleware', () => {
         },
       });
 
-      const actualArgs = extractArgsFromCalls(this.storageManager.storage);
-      expect(actualArgs).toEqual(['posts', 'users']);
+      const actualArgs = this.storageManager.storage.calls.allArgs();
+      expect(actualArgs).toEqual([['posts'], ['users']]);
     });
   });
 
@@ -73,7 +71,7 @@ describe('sync-brainstem middleware', () => {
       this.store.dispatch({
         type: 'UNRELATED_ACTION',
       });
-      const actualArgs = extractArgsFromCalls(this.storageManager.storage);
+      const actualArgs = this.storageManager.storage.calls.allArgs();
       expect(actualArgs).toEqual([]);
     });
   });

--- a/spec/middleware/sync-storage-manager-spec.js
+++ b/spec/middleware/sync-storage-manager-spec.js
@@ -50,7 +50,7 @@ describe('sync-brainstem middleware', () => {
   });
 
   describe('when skipSyncBrainstem is true', () => {
-    it('does not synce with the storageManager', function () {
+    it('does not sync with the storageManager', function () {
       this.store.dispatch({
         type: 'REMOVE_MODEL',
         payload: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When developing a Visual Master Planning feature that emitted frequent redux actions, I noticed that for every action, `syncBrainstem` was called from brainstem-redux. This is a relatively costly function, so it makes sense to only run `syncBrainstem` if `state.braimsten` has changed.

To achieve that goal, this PR adds a simple equality check to see if `state.brainstem` has changed as a result of a given action and runs `syncBrainstem` only if it has. Due to the immutable nature of the state tree, we get this type of comparison for "free". Shoutout to @juanca for the idea!

Conditionally running `syncBrainstem` should improve the overall speed of any feature that emits actions using brainstem-redux.

**Test plan**

Following the existing testing patterns, I've added a couple tests that verify that `storageManager.storage` is called with a total of either zero or two arguments. This works to verify if `syncBrainstem` is called or not because `storageManage.storage` is called two times during `syncBrainstem` and zero when `syncBrainstem` is not called, given the current test setup.

**General upkeep checklist**

- [x] Examples are working
