### PR TITLE
Make options object as second param of makeBrainstemType

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,13 @@ module.exports = Object.assign({},
 );
 ```
 
-`makeBrainstemType` also takes an optional `filter` argument that allows you to return only a subset of the models in a collection:
+`makeBrainstemType` also takes an optional `typeOptions` argument.
+Currently, it supports a `filterPredicate` key that allows you to return only a subset of the models in a collection:
 
 ```js
 const { makeBrainstemType } = require('brainstem-redux');
 
-module.exports = makeBrainstemType('posts', post => !post.published);
+module.exports = makeBrainstemType('posts', { filterPredicate: post => !post.published });
 ```
 
 #### Using a Type

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -2,10 +2,14 @@ const isObject = require('lodash.isobject');
 const collectionActions = require('../actions/collection');
 const modelActions = require('../actions/model');
 
-module.exports = function makeBrainstemType(brainstemKey, filterPredicate = () => true) {
+const defaultTypeOptions = {
+  filterPredicate: () => true,
+};
+
+module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultTypeOptions) {
   function all(state) {
     return Object.keys(state.brainstem[brainstemKey])
-      .filter(id => filterPredicate(state.brainstem[brainstemKey][id]))
+      .filter(id => typeOptions.filterPredicate(state.brainstem[brainstemKey][id]))
       .reduce((memo, id) => {
         memo[id] = state.brainstem[brainstemKey][id]; // eslint-disable-line no-param-reassign
         return memo;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.34-alpha.1",
+  "version": "0.0.34",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.33",
+  "version": "0.0.34-alpha.1",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [
@@ -48,6 +48,10 @@
     {
       "name": "Brandon Duff",
       "email": "bduff@mavenlink.com"
+    },
+    {
+      "name": "Ellie Day",
+      "email": "eday@mavenlink.com"
     }
   ],
   "repository": {

--- a/spec/types/make-brainstem-type-spec.js
+++ b/spec/types/make-brainstem-type-spec.js
@@ -26,6 +26,15 @@ describe('makeBrainstemType', () => {
       });
     });
 
+    describe('looking up all models in the state that return true for a filterPredicate passed into options', () => {
+      it('returns all models in the state tree', () => {
+        const typeWithDefaultScope = makeBrainstemType(brainstemKey, {
+          filterPredicate: model => model.id === '5',
+        });
+        expect(typeWithDefaultScope.all(state)).toEqual({ [model1.id]: model1 });
+      });
+    });
+
     describe('finding a model by id', () => {
       describe('when the model is present', () => {
         const id = model2.id;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This PR changes the method signature of `makeBrainstemType` to accept a `typeOptions` object as the second param, instead of a filterPredicate function. The existing filterPredicate function is now accessible via a key in the options object. The README was also updated to reflect this changes.

The motivation for this PR is to allow additional options to be passed into `makeBrainstemType`, which will be required for planned changes involving the optional lessened use of storageManager via the functions returned by `makeBrainstemType`.

Additionally, specs were added to insure filtering still works as expected. Tests for the filtering predicate were not present before this PR.

**Test plan**

There is one usage in the mavenlink repo of a second param for `makeBrainstemType` and [this PR](https://github.com/mavenlink/mavenlink/pull/10270) has been made on mavenlink/mavenlink to update to the new method signature.

It might make sense to publish an alpha release so that we can test the new brainstem changes in CI as if a test is present involving the Type that uses the second param, it will fail.

**General upkeep checklist**

- [ ] Examples are working
