### PR TITLE
Implement initial default adapter for upcoming adapter pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,13 @@ module.exports = Object.assign({},
 );
 ```
 
-`makeBrainstemType` also takes an optional `filter` argument that allows you to return only a subset of the models in a collection:
+`makeBrainstemType` also takes an optional `typeOptions` argument.
+Currently, it supports a `filterPredicate` key that allows you to return only a subset of the models in a collection:
 
 ```js
 const { makeBrainstemType } = require('brainstem-redux');
 
-module.exports = makeBrainstemType('posts', post => !post.published);
+module.exports = makeBrainstemType('posts', { filterPredicate: post => !post.published });
 ```
 
 #### Using a Type

--- a/README.md
+++ b/README.md
@@ -423,3 +423,10 @@ collectionActions.fetch('posts', {
 ## Local Development
 
 In order to develop against a local checkout, run `yarn link` in `brainstem-redux`, then `yarn link brainstem-redux` in the project you want to use it in and restart webpack. Also, make sure to `yarn compile` when making changes in `brainstem-redux`.
+
+## Running example
+
+1. run `yarn start`
+2. navigate to `http://localhost:8080/webpack-dev-server/`
+3. click on `example`
+4. view example app and type an approved string into the search bar 

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -20,15 +20,19 @@ module.exports = {
       const xhr = adapter.fetchCollection(brainstemKey, {
         dispatch,
         getState,
-        fetchOptions
+        fetchOptions,
       });
 
-      if (postFetchAction) xhr.done(collection => dispatch(postFetchAction(collection.pluck('id'))));
+      if (postFetchAction) {
+        xhr.done(collection =>
+          dispatch(postFetchAction(adapter.collectionToIds(collection)))
+        );
+      }
 
       if (trackKey) xhrs[trackKey] = xhr;
 
       return new Promise((resolve, reject) => xhr
-        .done(collection => resolve(collection.map(model => model.attributes)))
+        .done(collection => resolve(adapter.collectionToArray(collection)))
         .fail(reject)
       );
     };

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -2,6 +2,14 @@ const { StorageManager } = require('brainstem-js');
 
 const xhrs = {};
 
+const storageManagerAdapter = {
+  fetch: (brainstemKey, options) => {
+    const storageManager = StorageManager.get();
+    return storageManager.storage(brainstemKey)
+      .fetch(Object.assign(options.fetchOptions, { remove: false }));
+  },
+}
+
 module.exports = {
   fetch(brainstemKey, options = {}) {
     const {
@@ -9,17 +17,15 @@ module.exports = {
       postFetchAction,
       preFetchAction,
       trackKey,
+      adapter = storageManagerAdapter,
     } = options;
-
-    const storageManager = StorageManager.get();
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
 
     return (dispatch) => {
       if (preFetchAction) dispatch(preFetchAction);
 
-      const xhr = storageManager.storage(brainstemKey)
-        .fetch(Object.assign(fetchOptions, { remove: false }));
+      const xhr = adapter.fetch(brainstemKey, { fetchOptions });
 
       if (postFetchAction) xhr.done(collection => dispatch(postFetchAction(collection.pluck('id'))));
 

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -8,7 +8,7 @@ const storageManagerAdapter = {
     return storageManager.storage(brainstemKey)
       .fetch(Object.assign(options.fetchOptions, { remove: false }));
   },
-}
+};
 
 module.exports = {
   fetch(brainstemKey, options = {}) {

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -1,14 +1,6 @@
-const { StorageManager } = require('brainstem-js');
+const defaultAdapter = require('../adapters/default');
 
 const xhrs = {};
-
-const storageManagerAdapter = {
-  fetchCollection: (brainstemKey, options) => {
-    const storageManager = StorageManager.get();
-    return storageManager.storage(brainstemKey)
-      .fetch(Object.assign(options.fetchOptions, { remove: false }));
-  },
-};
 
 module.exports = {
   fetch(brainstemKey, options = {}) {
@@ -17,7 +9,7 @@ module.exports = {
       postFetchAction,
       preFetchAction,
       trackKey,
-      adapter = storageManagerAdapter,
+      adapter = defaultAdapter,
     } = options;
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -3,7 +3,7 @@ const { StorageManager } = require('brainstem-js');
 const xhrs = {};
 
 const storageManagerAdapter = {
-  fetch: (brainstemKey, options) => {
+  fetchCollection: (brainstemKey, options) => {
     const storageManager = StorageManager.get();
     return storageManager.storage(brainstemKey)
       .fetch(Object.assign(options.fetchOptions, { remove: false }));
@@ -25,7 +25,7 @@ module.exports = {
     return (dispatch) => {
       if (preFetchAction) dispatch(preFetchAction);
 
-      const xhr = adapter.fetch(brainstemKey, { fetchOptions });
+      const xhr = adapter.fetchCollection(brainstemKey, { fetchOptions });
 
       if (postFetchAction) xhr.done(collection => dispatch(postFetchAction(collection.pluck('id'))));
 

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -14,10 +14,14 @@ module.exports = {
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
 
-    return (dispatch) => {
+    return (dispatch, getState) => {
       if (preFetchAction) dispatch(preFetchAction);
 
-      const xhr = adapter.fetchCollection(brainstemKey, { fetchOptions });
+      const xhr = adapter.fetchCollection(brainstemKey, {
+        dispatch,
+        getState,
+        fetchOptions
+      });
 
       if (postFetchAction) xhr.done(collection => dispatch(postFetchAction(collection.pluck('id'))));
 

--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -3,6 +3,31 @@ const $ = require('jquery');
 
 const xhrs = {};
 
+const storageManagerAdapter = {
+  fetchModel: (brainstemKey, modelId, options) => {
+    const storageManager = StorageManager.get();
+    const Model = storageManager.storage(brainstemKey).model;
+    return new Model({ id: modelId })
+      .fetch(Object.assign(options.fetchOptions, { remove: false }));
+  },
+  saveModel: (brainstemKey, modelId, attributes, options) => {
+    const storageManager = StorageManager.get();
+    const Model = storageManager.storage(brainstemKey).model;
+    return new Model({ id: modelId })
+      .save(attributes, options.saveOptions);
+  },
+  destroyModel: (brainstemKey, modelId, options) => {
+    const storageManager = StorageManager.get();
+    const Model = storageManager.storage(brainstemKey).model;
+    return new Model({ id: modelId }).destroy(options.deleteOptions);
+  },
+  validateModel: (brainstemKey, attributes, options) => {
+    const storageManager = StorageManager.get();
+    const Model = storageManager.storage(brainstemKey).model;
+    return new Model().validate(attributes, options.validateOptions);
+  }
+}
+
 module.exports = {
   fetch(brainstemKey, modelId, options = {}) {
     const {
@@ -10,18 +35,15 @@ module.exports = {
       postFetchAction,
       preFetchAction,
       trackKey,
+      adapter = storageManagerAdapter,
     } = options;
-
-    const storageManager = StorageManager.get();
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
 
     return (dispatch) => {
       if (preFetchAction) dispatch(preFetchAction);
 
-      const Model = storageManager.storage(brainstemKey).model;
-      const xhr = new Model({ id: modelId })
-        .fetch(Object.assign(fetchOptions, { remove: false }));
+      const xhr = adapter.fetchModel(brainstemKey, modelId, { fetchOptions });
 
       if (postFetchAction) xhr.done(model => dispatch(postFetchAction(model.get('id'))));
 
@@ -37,6 +59,7 @@ module.exports = {
       preSaveAction,
       postSaveAction,
       trackKey,
+      adapter = storageManagerAdapter,
     } = options;
 
     const storageManager = StorageManager.get();
@@ -46,9 +69,7 @@ module.exports = {
     return (dispatch) => {
       if (preSaveAction) dispatch(preSaveAction);
 
-      const Model = storageManager.storage(brainstemKey).model;
-      let xhr = new Model({ id: modelId })
-        .save(attributes, saveOptions);
+      let xhr = adapter.saveModel(brainstemKey, modelId, attributes, { saveOptions });
 
       // backbone returns false when the model is invalid
       if (!xhr.then) {
@@ -75,13 +96,14 @@ module.exports = {
     const {
       deleteOptions = {},
       trackKey,
+      adapter = storageManagerAdapter,
     } = options;
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
 
     return () => {
-      const Model = storageManager.storage(brainstemKey).model;
-      const xhr = new Model({ id: modelId }).destroy(deleteOptions);
+      const xhr = adapter.destroyModel(brainstemKey, modelId, { deleteOptions });
+
       if (trackKey) xhrs[trackKey] = xhr;
 
       return xhr;
@@ -93,15 +115,13 @@ module.exports = {
       validateOptions = {},
       preValidateAction,
       postValidateAction,
+      adapter = storageManagerAdapter,
     } = options;
-
-    const storageManager = StorageManager.get();
 
     return (dispatch) => {
       if (preValidateAction) dispatch(preValidateAction);
 
-      const Model = storageManager.storage(brainstemKey).model;
-      const validationErrors = new Model().validate(attributes, validateOptions);
+      const validationErrors = adapter.validateModel(brainstemKey, attributes, { validateOptions })
 
       if (postValidateAction) { dispatch(postValidateAction(validationErrors)); }
 

--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -15,10 +15,14 @@ module.exports = {
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
 
-    return (dispatch) => {
+    return (dispatch, getState) => {
       if (preFetchAction) dispatch(preFetchAction);
 
-      const xhr = adapter.fetchModel(brainstemKey, modelId, { fetchOptions });
+      const xhr = adapter.fetchModel(brainstemKey, modelId, {
+        dispatch,
+        getState,
+        fetchOptions
+      });
 
       if (postFetchAction) xhr.done(model => dispatch(postFetchAction(model.get('id'))));
 
@@ -39,10 +43,14 @@ module.exports = {
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
 
-    return (dispatch) => {
+    return (dispatch, getState) => {
       if (preSaveAction) dispatch(preSaveAction);
 
-      let xhr = adapter.saveModel(brainstemKey, modelId, attributes, { saveOptions });
+      let xhr = adapter.saveModel(brainstemKey, modelId, attributes, {
+        dispatch,
+        getState,
+        saveOptions
+      });
 
       // backbone returns false when the model is invalid
       if (!xhr.then) {
@@ -73,8 +81,12 @@ module.exports = {
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
 
-    return () => {
-      const xhr = adapter.destroyModel(brainstemKey, modelId, { deleteOptions });
+    return (dispatch, getState) => {
+      const xhr = adapter.destroyModel(brainstemKey, modelId, {
+        dispatch,
+        getState,
+        deleteOptions
+      });
 
       if (trackKey) xhrs[trackKey] = xhr;
 
@@ -90,10 +102,14 @@ module.exports = {
       adapter = defaultAdapter,
     } = options;
 
-    return (dispatch) => {
+    return (dispatch, getState) => {
       if (preValidateAction) dispatch(preValidateAction);
 
-      const validationErrors = adapter.validateModel(brainstemKey, attributes, { validateOptions });
+      const validationErrors = adapter.validateModel(brainstemKey, attributes, {
+        dispatch,
+        getState,
+        validateOptions,
+      });
 
       if (postValidateAction) { dispatch(postValidateAction(validationErrors)); }
 

--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -25,8 +25,8 @@ const storageManagerAdapter = {
     const storageManager = StorageManager.get();
     const Model = storageManager.storage(brainstemKey).model;
     return new Model().validate(attributes, options.validateOptions);
-  }
-}
+  },
+};
 
 module.exports = {
   fetch(brainstemKey, modelId, options = {}) {
@@ -62,8 +62,6 @@ module.exports = {
       adapter = storageManagerAdapter,
     } = options;
 
-    const storageManager = StorageManager.get();
-
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
 
     return (dispatch) => {
@@ -92,7 +90,6 @@ module.exports = {
   },
 
   destroy(brainstemKey, modelId, options = {}) {
-    const storageManager = StorageManager.get();
     const {
       deleteOptions = {},
       trackKey,
@@ -121,7 +118,7 @@ module.exports = {
     return (dispatch) => {
       if (preValidateAction) dispatch(preValidateAction);
 
-      const validationErrors = adapter.validateModel(brainstemKey, attributes, { validateOptions })
+      const validationErrors = adapter.validateModel(brainstemKey, attributes, { validateOptions });
 
       if (postValidateAction) { dispatch(postValidateAction(validationErrors)); }
 

--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -21,7 +21,7 @@ module.exports = {
       const xhr = adapter.fetchModel(brainstemKey, modelId, {
         dispatch,
         getState,
-        fetchOptions
+        fetchOptions,
       });
 
       if (postFetchAction) xhr.done(model => dispatch(postFetchAction(model.get('id'))));
@@ -49,7 +49,7 @@ module.exports = {
       let xhr = adapter.saveModel(brainstemKey, modelId, attributes, {
         dispatch,
         getState,
-        saveOptions
+        saveOptions,
       });
 
       // backbone returns false when the model is invalid
@@ -85,7 +85,7 @@ module.exports = {
       const xhr = adapter.destroyModel(brainstemKey, modelId, {
         dispatch,
         getState,
-        deleteOptions
+        deleteOptions,
       });
 
       if (trackKey) xhrs[trackKey] = xhr;

--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -1,32 +1,7 @@
-const { StorageManager } = require('brainstem-js');
 const $ = require('jquery');
+const defaultAdapter = require('../adapters/default');
 
 const xhrs = {};
-
-const storageManagerAdapter = {
-  fetchModel: (brainstemKey, modelId, options) => {
-    const storageManager = StorageManager.get();
-    const Model = storageManager.storage(brainstemKey).model;
-    return new Model({ id: modelId })
-      .fetch(Object.assign(options.fetchOptions, { remove: false }));
-  },
-  saveModel: (brainstemKey, modelId, attributes, options) => {
-    const storageManager = StorageManager.get();
-    const Model = storageManager.storage(brainstemKey).model;
-    return new Model({ id: modelId })
-      .save(attributes, options.saveOptions);
-  },
-  destroyModel: (brainstemKey, modelId, options) => {
-    const storageManager = StorageManager.get();
-    const Model = storageManager.storage(brainstemKey).model;
-    return new Model({ id: modelId }).destroy(options.deleteOptions);
-  },
-  validateModel: (brainstemKey, attributes, options) => {
-    const storageManager = StorageManager.get();
-    const Model = storageManager.storage(brainstemKey).model;
-    return new Model().validate(attributes, options.validateOptions);
-  },
-};
 
 module.exports = {
   fetch(brainstemKey, modelId, options = {}) {
@@ -35,7 +10,7 @@ module.exports = {
       postFetchAction,
       preFetchAction,
       trackKey,
-      adapter = storageManagerAdapter,
+      adapter = defaultAdapter,
     } = options;
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
@@ -59,7 +34,7 @@ module.exports = {
       preSaveAction,
       postSaveAction,
       trackKey,
-      adapter = storageManagerAdapter,
+      adapter = defaultAdapter,
     } = options;
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
@@ -93,7 +68,7 @@ module.exports = {
     const {
       deleteOptions = {},
       trackKey,
-      adapter = storageManagerAdapter,
+      adapter = defaultAdapter,
     } = options;
 
     if (xhrs[trackKey] && xhrs[trackKey].state() === 'pending') xhrs[trackKey].abort();
@@ -112,7 +87,7 @@ module.exports = {
       validateOptions = {},
       preValidateAction,
       postValidateAction,
-      adapter = storageManagerAdapter,
+      adapter = defaultAdapter,
     } = options;
 
     return (dispatch) => {

--- a/lib/actions/model.js
+++ b/lib/actions/model.js
@@ -24,7 +24,7 @@ module.exports = {
         fetchOptions,
       });
 
-      if (postFetchAction) xhr.done(model => dispatch(postFetchAction(model.get('id'))));
+      if (postFetchAction) xhr.done(model => dispatch(postFetchAction(adapter.modelToId(model))));
 
       if (trackKey) xhrs[trackKey] = xhr;
 

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -28,4 +28,6 @@ module.exports = {
     const Model = storageManager.storage(brainstemKey).model;
     return new Model().validate(attributes, options.validateOptions);
   },
+  collectionToIds: collection => collection.pluck('id'),
+  collectionToArray: collection => collection.map(model => model.attributes),
 };

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -1,32 +1,31 @@
 const { StorageManager } = require('brainstem-js');
 
 module.exports = {
-  name: 'default',
-  connect: (actionName, dispatch, getState) => {
+  fetchCollection: (brainstemKey, options) => {
     const storageManager = StorageManager.get();
-    const actions = {
-      fetchCollection: (brainstemKey, options) => storageManager.storage(brainstemKey)
-          .fetch(Object.assign(options.fetchOptions, { remove: false })),
-      fetchModel: (brainstemKey, modelId, options) => {
-        const Model = storageManager.storage(brainstemKey).model;
-        return new Model({ id: modelId })
-          .fetch(Object.assign(options.fetchOptions, { remove: false }));
-      },
-      saveModel: (brainstemKey, modelId, attributes, options) => {
-        const Model = storageManager.storage(brainstemKey).model;
-        return new Model({ id: modelId })
-          .save(attributes, options.saveOptions);
-      },
-      destroyModel: (brainstemKey, modelId, options) => {
-        const Model = storageManager.storage(brainstemKey).model;
-        return new Model({ id: modelId }).destroy(options.deleteOptions);
-      },
-      validateModel: (brainstemKey, attributes, options) => {
-        const Model = storageManager.storage(brainstemKey).model;
-        return new Model().validate(attributes, options.validateOptions);
-      },
-    };
-
-    return actions[actionName];
+    return storageManager.storage(brainstemKey)
+      .fetch(Object.assign(options.fetchOptions, { remove: false }));
+  },
+  fetchModel: (brainstemKey, modelId, options) => {
+    const storageManager = StorageManager.get();
+    const Model = storageManager.storage(brainstemKey).model;
+    return new Model({ id: modelId })
+      .fetch(Object.assign(options.fetchOptions, { remove: false }));
+  },
+  saveModel: (brainstemKey, modelId, attributes, options) => {
+    const storageManager = StorageManager.get();
+    const Model = storageManager.storage(brainstemKey).model;
+    return new Model({ id: modelId })
+      .save(attributes, options.saveOptions);
+  },
+  destroyModel: (brainstemKey, modelId, options) => {
+    const storageManager = StorageManager.get();
+    const Model = storageManager.storage(brainstemKey).model;
+    return new Model({ id: modelId }).destroy(options.deleteOptions);
+  },
+  validateModel: (brainstemKey, attributes, options) => {
+    const storageManager = StorageManager.get();
+    const Model = storageManager.storage(brainstemKey).model;
+    return new Model().validate(attributes, options.validateOptions);
   },
 };

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -1,0 +1,32 @@
+const { StorageManager } = require('brainstem-js');
+
+module.exports = {
+  name: 'default',
+  connect: (actionName, dispatch, getState) => {
+    const storageManager = StorageManager.get();
+    const actions = {
+      fetchCollection: (brainstemKey, options) => storageManager.storage(brainstemKey)
+          .fetch(Object.assign(options.fetchOptions, { remove: false })),
+      fetchModel: (brainstemKey, modelId, options) => {
+        const Model = storageManager.storage(brainstemKey).model;
+        return new Model({ id: modelId })
+          .fetch(Object.assign(options.fetchOptions, { remove: false }));
+      },
+      saveModel: (brainstemKey, modelId, attributes, options) => {
+        const Model = storageManager.storage(brainstemKey).model;
+        return new Model({ id: modelId })
+          .save(attributes, options.saveOptions);
+      },
+      destroyModel: (brainstemKey, modelId, options) => {
+        const Model = storageManager.storage(brainstemKey).model;
+        return new Model({ id: modelId }).destroy(options.deleteOptions);
+      },
+      validateModel: (brainstemKey, attributes, options) => {
+        const Model = storageManager.storage(brainstemKey).model;
+        return new Model().validate(attributes, options.validateOptions);
+      },
+    };
+
+    return actions[actionName];
+  },
+};

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -30,4 +30,5 @@ module.exports = {
   },
   collectionToIds: collection => collection.pluck('id'),
   collectionToArray: collection => collection.map(model => model.attributes),
+  modelToId: model => model.get('id'),
 };

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -4,13 +4,13 @@ module.exports = {
   fetchCollection: (brainstemKey, options) => {
     const storageManager = StorageManager.get();
     return storageManager.storage(brainstemKey)
-      .fetch(Object.assign(options.fetchOptions, { remove: false }));
+      .fetch(Object.assign({}, options.fetchOptions, { remove: false }));
   },
   fetchModel: (brainstemKey, modelId, options) => {
     const storageManager = StorageManager.get();
     const Model = storageManager.storage(brainstemKey).model;
     return new Model({ id: modelId })
-      .fetch(Object.assign(options.fetchOptions, { remove: false }));
+      .fetch(Object.assign({}, options.fetchOptions, { remove: false }));
   },
   saveModel: (brainstemKey, modelId, attributes, options) => {
     const storageManager = StorageManager.get();

--- a/lib/reducers/index.js
+++ b/lib/reducers/index.js
@@ -14,6 +14,7 @@
 */
 
 const updateModel = require('./update-model');
+const syncCollections = require('./sync-collections');
 const removeModel = require('./remove-model');
 const initialState = require('./initial-state');
 
@@ -24,6 +25,8 @@ module.exports = (state = initialState(), action) => {
       return updateModel(state, action);
     case 'REMOVE_MODEL':
       return removeModel(state, action);
+    case 'SYNC_COLLECTIONS':
+      return syncCollections(state, action);
     default:
       return state;
   }

--- a/lib/reducers/sync-collections.js
+++ b/lib/reducers/sync-collections.js
@@ -1,0 +1,14 @@
+module.exports = (state, action) => {
+  const mergedCollections = {};
+  const { collections } = action.payload;
+  const collectionNames = Object.keys(collections);
+
+  collectionNames.forEach((collectionName) => {
+    mergedCollections[collectionName] = {
+      ...state[collectionName],
+      ...collections[collectionName],
+    };
+  });
+
+  return { ...state, ...mergedCollections };
+};

--- a/lib/reducers/sync-collections.js
+++ b/lib/reducers/sync-collections.js
@@ -4,11 +4,12 @@ module.exports = (state, action) => {
   const collectionNames = Object.keys(collections);
 
   collectionNames.forEach((collectionName) => {
-    mergedCollections[collectionName] = {
-      ...state[collectionName],
-      ...collections[collectionName],
-    };
+    mergedCollections[collectionName] = Object.assign(
+      {},
+      state[collectionName],
+      collections[collectionName],
+    );
   });
 
-  return { ...state, ...mergedCollections };
+  return Object.assign({}, state, mergedCollections);
 };

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -9,6 +9,11 @@ const defaultTypeOptions = {
 module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultTypeOptions) {
   const mergedOptions = { ...defaultTypeOptions, ...typeOptions };
 
+  const buildActionOptions = (options) => {
+    const { adapter } = mergedOptions;
+    return adapter ? { ...options, adapter } : options;
+  };
+
   function all(state) {
     return Object.keys(state.brainstem[brainstemKey])
       .filter(id => mergedOptions.filterPredicate(state.brainstem[brainstemKey][id]))
@@ -39,35 +44,19 @@ module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultT
   }
 
   function fetchAll(options) {
-    const optionsWithAdapter = mergedOptions.adapter ? {
-      ...options,
-      adapter: mergedOptions.adapter,
-    } : options;
-    return collectionActions.fetch(brainstemKey, optionsWithAdapter);
+    return collectionActions.fetch(brainstemKey, buildActionOptions(options));
   }
 
   function fetch(id, options) {
-    const optionsWithAdapter = mergedOptions.adapter ? {
-      ...options,
-      adapter: mergedOptions.adapter,
-    } : options;
-    return modelActions.fetch(brainstemKey, id, optionsWithAdapter);
+    return modelActions.fetch(brainstemKey, id, buildActionOptions(options));
   }
 
   function save(id, attributes, options) {
-    const optionsWithAdapter = mergedOptions.adapter ? {
-      ...options,
-      adapter: mergedOptions.adapter,
-    } : options;
-    return modelActions.save(brainstemKey, id, attributes, optionsWithAdapter);
+    return modelActions.save(brainstemKey, id, attributes, buildActionOptions(options));
   }
 
   function destroy(id, options) {
-    const optionsWithAdapter = mergedOptions.adapter ? {
-      ...options,
-      adapter: mergedOptions.adapter,
-    } : options;
-    return modelActions.destroy(brainstemKey, id, optionsWithAdapter);
+    return modelActions.destroy(brainstemKey, id, buildActionOptions(options));
   }
 
   function matchesAction({ meta, payload }) {

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -37,7 +37,8 @@ module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultT
   }
 
   function fetchAll(options) {
-    return collectionActions.fetch(brainstemKey, { ...options, adapter: typeOptions.adapter });
+    const optionsWithAdapter = typeOptions.adapter ? { ...options, adapter: typeOptions.adapter } : options;
+    return collectionActions.fetch(brainstemKey, optionsWithAdapter);
   }
 
   function fetch(id, options) {

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -7,9 +7,11 @@ const defaultTypeOptions = {
 };
 
 module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultTypeOptions) {
+  const mergedOptions = { ...defaultTypeOptions, ...typeOptions };
+
   function all(state) {
     return Object.keys(state.brainstem[brainstemKey])
-      .filter(id => typeOptions.filterPredicate(state.brainstem[brainstemKey][id]))
+      .filter(id => mergedOptions.filterPredicate(state.brainstem[brainstemKey][id]))
       .reduce((memo, id) => {
         memo[id] = state.brainstem[brainstemKey][id]; // eslint-disable-line no-param-reassign
         return memo;
@@ -37,23 +39,35 @@ module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultT
   }
 
   function fetchAll(options) {
-    const optionsWithAdapter = typeOptions.adapter ? {
+    const optionsWithAdapter = mergedOptions.adapter ? {
       ...options,
-      adapter: typeOptions.adapter,
+      adapter: mergedOptions.adapter,
     } : options;
     return collectionActions.fetch(brainstemKey, optionsWithAdapter);
   }
 
   function fetch(id, options) {
-    return modelActions.fetch(brainstemKey, id, options);
+    const optionsWithAdapter = mergedOptions.adapter ? {
+      ...options,
+      adapter: mergedOptions.adapter,
+    } : options;
+    return modelActions.fetch(brainstemKey, id, optionsWithAdapter);
   }
 
   function save(id, attributes, options) {
-    return modelActions.save(brainstemKey, id, attributes, options);
+    const optionsWithAdapter = mergedOptions.adapter ? {
+      ...options,
+      adapter: mergedOptions.adapter,
+    } : options;
+    return modelActions.save(brainstemKey, id, attributes, optionsWithAdapter);
   }
 
   function destroy(id, options) {
-    return modelActions.destroy(brainstemKey, id, options);
+    const optionsWithAdapter = mergedOptions.adapter ? {
+      ...options,
+      adapter: mergedOptions.adapter,
+    } : options;
+    return modelActions.destroy(brainstemKey, id, optionsWithAdapter);
   }
 
   function matchesAction({ meta, payload }) {

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -37,7 +37,10 @@ module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultT
   }
 
   function fetchAll(options) {
-    const optionsWithAdapter = typeOptions.adapter ? { ...options, adapter: typeOptions.adapter } : options;
+    const optionsWithAdapter = typeOptions.adapter ? {
+      ...options,
+      adapter: typeOptions.adapter,
+    } : options;
     return collectionActions.fetch(brainstemKey, optionsWithAdapter);
   }
 

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -2,10 +2,14 @@ const isObject = require('lodash.isobject');
 const collectionActions = require('../actions/collection');
 const modelActions = require('../actions/model');
 
-module.exports = function makeBrainstemType(brainstemKey, filterPredicate = () => true) {
+const defaultTypeOptions = {
+  filterPredicate: () => true,
+};
+
+module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultTypeOptions) {
   function all(state) {
     return Object.keys(state.brainstem[brainstemKey])
-      .filter(id => filterPredicate(state.brainstem[brainstemKey][id]))
+      .filter(id => typeOptions.filterPredicate(state.brainstem[brainstemKey][id]))
       .reduce((memo, id) => {
         memo[id] = state.brainstem[brainstemKey][id]; // eslint-disable-line no-param-reassign
         return memo;

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -7,11 +7,11 @@ const defaultTypeOptions = {
 };
 
 module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultTypeOptions) {
-  const mergedOptions = { ...defaultTypeOptions, ...typeOptions };
+  const mergedOptions = Object.assign({}, defaultTypeOptions, typeOptions);
 
   const buildActionOptions = (options) => {
     const { adapter } = mergedOptions;
-    return adapter ? { ...options, adapter } : options;
+    return adapter ? Object.assign({}, options, { adapter }) : options;
   };
 
   function all(state) {

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -37,7 +37,7 @@ module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultT
   }
 
   function fetchAll(options) {
-    return collectionActions.fetch(brainstemKey, options);
+    return collectionActions.fetch(brainstemKey, { ...options, adapter: typeOptions.adapter });
   }
 
   function fetch(id, options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.35-beta.1",
+  "version": "0.0.35",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.33",
+  "version": "0.0.34-alpha.1",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [
@@ -48,6 +48,10 @@
     {
       "name": "Brandon Duff",
       "email": "bduff@mavenlink.com"
+    },
+    {
+      "name": "Ellie Day",
+      "email": "eday@mavenlink.com"
     }
   ],
   "repository": {

--- a/spec/actions/collection-spec.js
+++ b/spec/actions/collection-spec.js
@@ -75,7 +75,7 @@ describe('collection action creators', () => {
     it('uses the adapter', function () {
       const deferred = $.Deferred(); // eslint-disable-line new-cap
       const stubAdapter = {
-        fetch: jasmine.createSpy('fetch').and.returnValue(deferred),
+        fetchCollection: jasmine.createSpy('fetchCollection').and.returnValue(deferred),
       };
       const fetchOptions = { filters: { foo: 'bar' } };
       this.store.dispatch(this.fetch('posts', {
@@ -83,7 +83,7 @@ describe('collection action creators', () => {
         adapter: stubAdapter,
       }));
 
-      expect(stubAdapter.fetch).toHaveBeenCalledWith('posts', { fetchOptions });
+      expect(stubAdapter.fetchCollection).toHaveBeenCalledWith('posts', { fetchOptions });
     });
   });
 });

--- a/spec/actions/collection-spec.js
+++ b/spec/actions/collection-spec.js
@@ -83,7 +83,11 @@ describe('collection action creators', () => {
         adapter: stubAdapter,
       }));
 
-      expect(stubAdapter.fetchCollection).toHaveBeenCalledWith('posts', { fetchOptions });
+      expect(stubAdapter.fetchCollection).toHaveBeenCalledWith('posts', {
+        dispatch: jasmine.any(Function),
+        getState: jasmine.any(Function),
+        fetchOptions,
+      });
     });
   });
 });

--- a/spec/actions/collection-spec.js
+++ b/spec/actions/collection-spec.js
@@ -10,62 +10,80 @@ describe('collection action creators', () => {
     this.storageManager.enableExpectations();
   });
 
-  it('fetches the collection', function () {
-    const expectation = this.storageManager.stub('posts', { filters: { foo: 'bar' } });
-    this.store.dispatch(this.fetch('posts', {
-      fetchOptions: { filters: { foo: 'bar' } },
-    }));
+  describe('default adapter', () => {
+    it('fetches the collection', function () {
+      const expectation = this.storageManager.stub('posts', { filters: { foo: 'bar' } });
+      this.store.dispatch(this.fetch('posts', {
+        fetchOptions: { filters: { foo: 'bar' } },
+      }));
 
-    expect(expectation.requestQueue.length).toBe(1);
+      expect(expectation.requestQueue.length).toBe(1);
+    });
+
+    describe('promise interface', () => {
+      it('exists', function () {
+        this.storageManager.stub('posts');
+        expect(this.store.dispatch(this.fetch('posts'))).toEqual(jasmine.any(Promise));
+      });
+
+      it('resolves with raw attributes when jqXHR is done', function (done) {
+        const postsModels = [new Post({ id: 1, title: 'Bar' }), new Post({ id: 2, title: 'Foo' })];
+        const expectation = this.storageManager.stub('posts', {
+          response(responseBody) {
+            responseBody.results = postsModels; // eslint-disable-line no-param-reassign
+          },
+        });
+        this.store.dispatch(this.fetch('posts')).then((response) => {
+          expect(response).toEqual(postsModels.map(model => model.attributes));
+          done();
+        });
+        expectation.respond();
+      });
+
+      it('rejects when jqXHR fails', function (done) {
+        const deferred = $.Deferred(); // eslint-disable-line new-cap
+        spyOn(this.storageManager.storage('posts'), 'fetch').and.returnValue(deferred);
+        this.store.dispatch(this.fetch('posts')).catch(done);
+        deferred.reject();
+      });
+    });
+
+    describe('previous XHRs', () => {
+      it('uses a trackKey to abort previous pending XHR', function () {
+        const abort = jasmine.createSpy('abort');
+        const state = () => 'pending';
+        spyOn(this.storageManager.storage('posts'), 'fetch').and.returnValue({ abort, state });
+        this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
+        this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
+
+        expect(abort).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not abort non-pending previous XHR', function () {
+        const abort = jasmine.createSpy('abort');
+        const state = () => 'resolved';
+        spyOn(this.storageManager.storage('posts'), 'fetch').and.returnValue({ abort, state });
+        this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
+        this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
+
+        expect(abort).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 
-  describe('promise interface', () => {
-    it('exists', function () {
-      this.storageManager.stub('posts');
-      expect(this.store.dispatch(this.fetch('posts'))).toEqual(jasmine.any(Promise));
-    });
-
-    it('resolves with raw attributes when jqXHR is done', function (done) {
-      const postsModels = [new Post({ id: 1, title: 'Bar' }), new Post({ id: 2, title: 'Foo' })];
-      const expectation = this.storageManager.stub('posts', {
-        response(responseBody) {
-          responseBody.results = postsModels; // eslint-disable-line no-param-reassign
-        },
-      });
-      this.store.dispatch(this.fetch('posts')).then((response) => {
-        expect(response).toEqual(postsModels.map(model => model.attributes));
-        done();
-      });
-      expectation.respond();
-    });
-
-    it('rejects when jqXHR fails', function (done) {
+  describe('when an adapter is passed in', () => {
+    it('uses the adapter', function () {
       const deferred = $.Deferred(); // eslint-disable-line new-cap
-      spyOn(this.storageManager.storage('posts'), 'fetch').and.returnValue(deferred);
-      this.store.dispatch(this.fetch('posts')).catch(done);
-      deferred.reject();
-    });
-  });
+      const stubAdapter = {
+        fetch: jasmine.createSpy('fetch').and.returnValue(deferred),
+      };
+      const fetchOptions = { filters: { foo: 'bar' } };
+      this.store.dispatch(this.fetch('posts', {
+        fetchOptions,
+        adapter: stubAdapter,
+      }));
 
-  describe('previous XHRs', () => {
-    it('uses a trackKey to abort previous pending XHR', function () {
-      const abort = jasmine.createSpy('abort');
-      const state = () => 'pending';
-      spyOn(this.storageManager.storage('posts'), 'fetch').and.returnValue({ abort, state });
-      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
-      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
-
-      expect(abort).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not abort non-pending previous XHR', function () {
-      const abort = jasmine.createSpy('abort');
-      const state = () => 'resolved';
-      spyOn(this.storageManager.storage('posts'), 'fetch').and.returnValue({ abort, state });
-      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
-      this.store.dispatch(this.fetch('posts', { trackKey: 'foo' })).catch(() => {});
-
-      expect(abort).toHaveBeenCalledTimes(0);
+      expect(stubAdapter.fetch).toHaveBeenCalledWith('posts', { fetchOptions });
     });
   });
 });

--- a/spec/actions/model-spec.js
+++ b/spec/actions/model-spec.js
@@ -51,7 +51,7 @@ describe('model action creators', () => {
         this.save = modelActions.save;
       });
 
-      it('send save to the subscriber for the existing model', function () {
+      it('sends save to the subscriber for the existing model', function () {
         const posts = this.storageManager.storage('posts');
         posts.add({ id: 1, title: 'What is redux?', message: 'I do not know but it might be awesome' });
         const model = posts.last();

--- a/spec/actions/model-spec.js
+++ b/spec/actions/model-spec.js
@@ -8,125 +8,240 @@ describe('model action creators', () => {
     this.storageManager.enableExpectations();
   });
 
-  describe('fetch', () => {
-    beforeEach(function () {
-      this.fetch = modelActions.fetch;
-    });
-
-    it('fetches the model', function () {
-      const expectation = this.storageManager.stubModel('posts', '76', { filters: { foo: 'baz' } });
-      this.store.dispatch(this.fetch('posts', '76', {
-        fetchOptions: { filters: { foo: 'baz' } },
-      }));
-
-      expect(expectation.requestQueue.length).toBe(1);
-    });
-
-    describe('previous XHRs', () => {
-      it('uses a trackKey to abort previous pending XHR', function () {
-        const abort = jasmine.createSpy('abort');
-        const state = () => 'pending';
-        spyOn(this.storageManager.storage('posts').model.prototype, 'fetch').and.returnValue({ abort, state });
-        this.store.dispatch(this.fetch('posts', '76', { trackKey: 'foo' }));
-        this.store.dispatch(this.fetch('posts', '76', { trackKey: 'foo' }));
-
-        expect(abort).toHaveBeenCalledTimes(1);
+  describe('default adapter', () => {
+    describe('fetch', () => {
+      beforeEach(function () {
+        this.fetch = modelActions.fetch;
       });
 
-      it('does not abort non-pending previous XHR', function () {
-        const abort = jasmine.createSpy('abort');
-        const state = () => 'resolved';
-        spyOn(this.storageManager.storage('posts').model.prototype, 'fetch').and.returnValue({ abort, state });
-        this.store.dispatch(this.fetch('posts', '76', { trackKey: 'foo' }));
-        this.store.dispatch(this.fetch('posts', '76', { trackKey: 'foo' }));
+      it('fetches the model', function () {
+        const expectation = this.storageManager.stubModel('posts', '76', { filters: { foo: 'baz' } });
+        this.store.dispatch(this.fetch('posts', '76', {
+          fetchOptions: { filters: { foo: 'baz' } },
+        }));
 
-        expect(abort).toHaveBeenCalledTimes(0);
+        expect(expectation.requestQueue.length).toBe(1);
+      });
+
+      describe('previous XHRs', () => {
+        it('uses a trackKey to abort previous pending XHR', function () {
+          const abort = jasmine.createSpy('abort');
+          const state = () => 'pending';
+          spyOn(this.storageManager.storage('posts').model.prototype, 'fetch').and.returnValue({ abort, state });
+          this.store.dispatch(this.fetch('posts', '76', { trackKey: 'foo' }));
+          this.store.dispatch(this.fetch('posts', '76', { trackKey: 'foo' }));
+
+          expect(abort).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not abort non-pending previous XHR', function () {
+          const abort = jasmine.createSpy('abort');
+          const state = () => 'resolved';
+          spyOn(this.storageManager.storage('posts').model.prototype, 'fetch').and.returnValue({ abort, state });
+          this.store.dispatch(this.fetch('posts', '76', { trackKey: 'foo' }));
+          this.store.dispatch(this.fetch('posts', '76', { trackKey: 'foo' }));
+
+          expect(abort).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    describe('save', () => {
+      beforeEach(function () {
+        this.save = modelActions.save;
+      });
+
+      it('send save to the subscriber for the existing model', function () {
+        const posts = this.storageManager.storage('posts');
+        posts.add({ id: 1, title: 'What is redux?', message: 'I do not know but it might be awesome' });
+        const model = posts.last();
+
+        const spy = spyOn(model, 'save').and.returnValue($.Deferred()); // eslint-disable-line new-cap
+
+        this.store.dispatch(this.save('posts', '1', {
+          title: 'new post',
+        }));
+
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('subscriber saves a non-persisted model', function () {
+        const save = jasmine.createSpy('save').and.returnValue($.Deferred()); // eslint-disable-line new-cap
+        const ModelSpy = spyOn(this.storageManager.storage('posts'), 'model');
+        ModelSpy.and.returnValue({ save });
+
+        this.store.dispatch(this.save('posts', undefined, {
+          title: 'new post',
+        }));
+
+        expect(ModelSpy).toHaveBeenCalledWith({ id: undefined });
+        expect(save).toHaveBeenCalled();
+      });
+
+      it('returns a deferred when the model is invalid', () => {
+        spyOn($, 'ajax').and.returnValue($.Deferred()); // eslint-disable-line new-cap
+
+        const attributes = {};
+        expect(modelActions.validate('posts', attributes)()).toEqual({ errors: 'needs a user' });
+
+        const dispatch = modelActions.save('posts', null, attributes, { trackKey: 'john-bonham' });
+        const xhr = dispatch();
+
+        expect(xhr.resolve).toBeUndefined();
+        expect(xhr.reject).toBeUndefined();
+        expect(xhr.done).toEqual(jasmine.any(Function));
+        expect(xhr.fail).toEqual(jasmine.any(Function));
+      });
+    });
+
+    describe('destroy', () => {
+      beforeEach(function () {
+        this.destroy = modelActions.destroy;
+      });
+
+      it('sends destroy to the subscriber for the existing model', function () {
+        const posts = this.storageManager.storage('posts');
+        posts.add({ id: 1, title: 'What is redux?', message: 'I do not know but it might be awesome' });
+        const model = posts.last();
+        this.spy = spyOn(model, 'destroy').and.returnValue($.Deferred()); // eslint-disable-line new-cap
+        this.store.dispatch(this.destroy('posts', '1'));
+
+        expect(this.spy).toHaveBeenCalled();
+      });
+
+      it('cancels previous requests with the same provided track key if they are pending', function () {
+        const xhrResultDouble = {
+          abort: jasmine.createSpy('abort'),
+          state: () => 'pending',
+        };
+        spyOn(this.storageManager.storage('posts').model.prototype, 'destroy').and.returnValue(xhrResultDouble);
+
+        this.store.dispatch(this.destroy('posts', '1', { trackKey: 'post-destroy' }));
+        this.store.dispatch(this.destroy('posts', '1', { trackKey: 'post-destroy' }));
+        expect(xhrResultDouble.abort).toHaveBeenCalledTimes(1);
+      });
+
+      it('is chainable with a success and failure callback', function () {
+        spyOn($, 'ajax').and.returnValue($.Deferred()); // eslint-disable-line new-cap
+
+        const dispatch = this.destroy('posts', '1');
+        const xhr = dispatch();
+        expect(xhr.done).toEqual(jasmine.any(Function));
+        expect(xhr.fail).toEqual(jasmine.any(Function));
+      });
+    });
+
+    describe('validate', () => {
+      beforeEach(function () {
+        this.validate = modelActions.validate;
+      });
+
+      it('calls validate with the correct params on a Model instance', function () {
+        const errors = ['error'];
+
+        const validate = jasmine.createSpy('validate').and.returnValue(errors); // eslint-disable-line new-cap
+        const ModelSpy = spyOn(this.storageManager.storage('posts'), 'model');
+        ModelSpy.and.returnValue({ validate });
+
+        const attributes = { title: 'new post' };
+        const validateOptions = { anything: 'anything' };
+
+        this.store.dispatch(this.validate('posts', attributes, {
+          validateOptions,
+        }));
+
+        expect(ModelSpy).toHaveBeenCalledWith();
+        expect(validate).toHaveBeenCalledWith(attributes, validateOptions);
       });
     });
   });
 
-  describe('save', () => {
-    beforeEach(function () {
-      this.save = modelActions.save;
+  describe('when an adapter is passed in', () => {
+    describe('fetch', () => {
+      beforeEach(function () {
+        this.fetch = modelActions.fetch;
+      });
+
+      it('calls fetch on the adapter', function () {
+        const deferred = $.Deferred(); // eslint-disable-line new-cap
+        const stubAdapter = {
+          fetchModel: jasmine.createSpy('fetchModel').and.returnValue(deferred),
+        };
+        const fetchOptions = { filters: { foo: 'bar' } };
+        this.store.dispatch(this.fetch('posts', '76', {
+          fetchOptions,
+          adapter: stubAdapter,
+        }));
+
+        expect(stubAdapter.fetchModel).toHaveBeenCalledWith('posts', '76', { fetchOptions });
+      });
     });
 
-    it('send save to the subscriber for the existing model', function () {
-      const posts = this.storageManager.storage('posts');
-      posts.add({ id: 1, title: 'What is redux?', message: 'I do not know but it might be awesome' });
-      const model = posts.last();
+    describe('save', () => {
+      beforeEach(function () {
+        this.save = modelActions.save;
+      });
 
-      const spy = spyOn(model, 'save').and.returnValue($.Deferred()); // eslint-disable-line new-cap
+      it('calls save on the adapter', function () {
+        const deferred = $.Deferred(); // eslint-disable-line new-cap
+        const stubAdapter = {
+          saveModel: jasmine.createSpy('saveModel').and.returnValue(deferred),
+        };
+        const saveOptions = { filters: { foo: 'bar' } };
+        const attributes = {};
+        this.store.dispatch(this.save('posts', '76', attributes, {
+          saveOptions,
+          adapter: stubAdapter,
+        }));
 
-      this.store.dispatch(this.save('posts', '1', {
-        title: 'new post',
-      }));
-
-      expect(spy).toHaveBeenCalled();
+        expect(stubAdapter.saveModel).toHaveBeenCalledWith('posts', '76', attributes, {
+           saveOptions
+        });
+      });
     });
 
-    it('subscriber saves a non-persisted model', function () {
-      const save = jasmine.createSpy('save').and.returnValue($.Deferred()); // eslint-disable-line new-cap
-      const ModelSpy = spyOn(this.storageManager.storage('posts'), 'model');
-      ModelSpy.and.returnValue({ save });
+    describe('destroy', () => {
+      beforeEach(function () {
+        this.destroy = modelActions.destroy;
+      });
 
-      this.store.dispatch(this.save('posts', undefined, {
-        title: 'new post',
-      }));
+      it('calls destroy on the adapter', function () {
+        it('calls fetch on the adapter', function () {
+          const deferred = $.Deferred(); // eslint-disable-line new-cap
+          const stubAdapter = {
+            destroyModel: jasmine.createSpy('destroyModel').and.returnValue(deferred),
+          };
+          const destroyOptions = { filters: { foo: 'bar' } };
+          this.store.dispatch(this.destroy('posts', '76', {
+            destroyOptions,
+            adapter: stubAdapter,
+          }));
 
-      expect(ModelSpy).toHaveBeenCalledWith({ id: undefined });
-      expect(save).toHaveBeenCalled();
+          expect(stubAdapter.destroyModel).toHaveBeenCalledWith('posts', '76', { destroyOptions });
+        });
+      });
     });
 
-    it('returns a deferred when the model is invalid', () => {
-      spyOn($, 'ajax').and.returnValue($.Deferred()); // eslint-disable-line new-cap
+    describe('validate', () => {
+      beforeEach(function () {
+        this.destroy = modelActions.destroy;
+      });
 
-      const attributes = {};
-      expect(modelActions.validate('posts', attributes)()).toEqual({ errors: 'needs a user' });
+      it('calls destroy on the adapter', function () {
+        it('calls fetch on the adapter', function () {
+          const deferred = $.Deferred(); // eslint-disable-line new-cap
+          const stubAdapter = {
+            validateModel: jasmine.createSpy('validateModel').and.returnValue(deferred),
+          };
+          const validateOptions = { filters: { foo: 'bar' } };
+          this.store.dispatch(this.validate('posts', {
+            validateOptions,
+            adapter: stubAdapter,
+          }));
 
-      const dispatch = modelActions.save('posts', null, attributes, { trackKey: 'john-bonham' });
-      const xhr = dispatch();
-
-      expect(xhr.resolve).toBeUndefined();
-      expect(xhr.reject).toBeUndefined();
-      expect(xhr.done).toEqual(jasmine.any(Function));
-      expect(xhr.fail).toEqual(jasmine.any(Function));
-    });
-  });
-
-  describe('destroy', () => {
-    beforeEach(function () {
-      this.destroy = modelActions.destroy;
-    });
-
-    it('sends destroy to the subscriber for the existing model', function () {
-      const posts = this.storageManager.storage('posts');
-      posts.add({ id: 1, title: 'What is redux?', message: 'I do not know but it might be awesome' });
-      const model = posts.last();
-      this.spy = spyOn(model, 'destroy').and.returnValue($.Deferred()); // eslint-disable-line new-cap
-      this.store.dispatch(this.destroy('posts', '1'));
-
-      expect(this.spy).toHaveBeenCalled();
-    });
-
-    it('cancels previous requests with the same provided track key if they are pending', function () {
-      const xhrResultDouble = {
-        abort: jasmine.createSpy('abort'),
-        state: () => 'pending',
-      };
-      spyOn(this.storageManager.storage('posts').model.prototype, 'destroy').and.returnValue(xhrResultDouble);
-
-      this.store.dispatch(this.destroy('posts', '1', { trackKey: 'post-destroy' }));
-      this.store.dispatch(this.destroy('posts', '1', { trackKey: 'post-destroy' }));
-      expect(xhrResultDouble.abort).toHaveBeenCalledTimes(1);
-    });
-
-    it('is chainable with a success and failure callback', function () {
-      spyOn($, 'ajax').and.returnValue($.Deferred()); // eslint-disable-line new-cap
-
-      const dispatch = this.destroy('posts', '1');
-      const xhr = dispatch();
-      expect(xhr.done).toEqual(jasmine.any(Function));
-      expect(xhr.fail).toEqual(jasmine.any(Function));
+          expect(stubAdapter.validateModel).toHaveBeenCalledWith('posts', { validateOptions });
+        });
+      });
     });
   });
 });

--- a/spec/actions/model-spec.js
+++ b/spec/actions/model-spec.js
@@ -195,7 +195,7 @@ describe('model action creators', () => {
         }));
 
         expect(stubAdapter.saveModel).toHaveBeenCalledWith('posts', '76', attributes, {
-           saveOptions
+          saveOptions,
         });
       });
     });
@@ -205,7 +205,7 @@ describe('model action creators', () => {
         this.destroy = modelActions.destroy;
       });
 
-      it('calls destroy on the adapter', function () {
+      it('calls destroy on the adapter', () => {
         it('calls fetch on the adapter', function () {
           const deferred = $.Deferred(); // eslint-disable-line new-cap
           const stubAdapter = {
@@ -227,7 +227,7 @@ describe('model action creators', () => {
         this.destroy = modelActions.destroy;
       });
 
-      it('calls destroy on the adapter', function () {
+      it('calls destroy on the adapter', () => {
         it('calls fetch on the adapter', function () {
           const deferred = $.Deferred(); // eslint-disable-line new-cap
           const stubAdapter = {

--- a/spec/actions/model-spec.js
+++ b/spec/actions/model-spec.js
@@ -173,7 +173,11 @@ describe('model action creators', () => {
           adapter: stubAdapter,
         }));
 
-        expect(stubAdapter.fetchModel).toHaveBeenCalledWith('posts', '76', { fetchOptions });
+        expect(stubAdapter.fetchModel).toHaveBeenCalledWith('posts', '76', {
+          dispatch: jasmine.any(Function),
+          getState: jasmine.any(Function),
+          fetchOptions,
+         });
       });
     });
 
@@ -195,6 +199,8 @@ describe('model action creators', () => {
         }));
 
         expect(stubAdapter.saveModel).toHaveBeenCalledWith('posts', '76', attributes, {
+          dispatch: jasmine.any(Function),
+          getState: jasmine.any(Function),
           saveOptions,
         });
       });
@@ -217,7 +223,11 @@ describe('model action creators', () => {
             adapter: stubAdapter,
           }));
 
-          expect(stubAdapter.destroyModel).toHaveBeenCalledWith('posts', '76', { destroyOptions });
+          expect(stubAdapter.destroyModel).toHaveBeenCalledWith('posts', '76', {
+            dispatch: jasmine.any(Function),
+            getState: jasmine.any(Function),
+            destroyOptions,
+           });
         });
       });
     });
@@ -239,7 +249,11 @@ describe('model action creators', () => {
             adapter: stubAdapter,
           }));
 
-          expect(stubAdapter.validateModel).toHaveBeenCalledWith('posts', { validateOptions });
+          expect(stubAdapter.validateModel).toHaveBeenCalledWith('posts', {
+            dispatch: jasmine.any(Function),
+            getState: jasmine.any(Function),
+            validateOptions,
+           });
         });
       });
     });

--- a/spec/actions/model-spec.js
+++ b/spec/actions/model-spec.js
@@ -211,49 +211,46 @@ describe('model action creators', () => {
         this.destroy = modelActions.destroy;
       });
 
-      it('calls destroy on the adapter', () => {
-        it('calls fetch on the adapter', function () {
-          const deferred = $.Deferred(); // eslint-disable-line new-cap
-          const stubAdapter = {
-            destroyModel: jasmine.createSpy('destroyModel').and.returnValue(deferred),
-          };
-          const destroyOptions = { filters: { foo: 'bar' } };
-          this.store.dispatch(this.destroy('posts', '76', {
-            destroyOptions,
-            adapter: stubAdapter,
-          }));
+      it('calls destroy on the adapter', function () {
+        const deferred = $.Deferred(); // eslint-disable-line new-cap
+        const stubAdapter = {
+          destroyModel: jasmine.createSpy('destroyModel').and.returnValue(deferred),
+        };
+        const deleteOptions = { filters: { foo: 'bar' } };
+        this.store.dispatch(this.destroy('posts', '76', {
+          deleteOptions,
+          adapter: stubAdapter,
+        }));
 
-          expect(stubAdapter.destroyModel).toHaveBeenCalledWith('posts', '76', {
-            dispatch: jasmine.any(Function),
-            getState: jasmine.any(Function),
-            destroyOptions,
-          });
+        expect(stubAdapter.destroyModel).toHaveBeenCalledWith('posts', '76', {
+          dispatch: jasmine.any(Function),
+          getState: jasmine.any(Function),
+          deleteOptions,
         });
       });
     });
 
     describe('validate', () => {
       beforeEach(function () {
-        this.destroy = modelActions.destroy;
+        this.validate = modelActions.validate;
       });
 
-      it('calls destroy on the adapter', () => {
-        it('calls fetch on the adapter', function () {
-          const deferred = $.Deferred(); // eslint-disable-line new-cap
-          const stubAdapter = {
-            validateModel: jasmine.createSpy('validateModel').and.returnValue(deferred),
-          };
-          const validateOptions = { filters: { foo: 'bar' } };
-          this.store.dispatch(this.validate('posts', {
-            validateOptions,
-            adapter: stubAdapter,
-          }));
+      it('calls validate on the adapter', function () {
+        const deferred = $.Deferred(); // eslint-disable-line new-cap
+        const stubAdapter = {
+          validateModel: jasmine.createSpy('validateModel').and.returnValue(deferred),
+        };
+        const validateOptions = { };
+        const attributes = { foo: 'bar' };
+        this.store.dispatch(this.validate('posts', attributes, {
+          validateOptions,
+          adapter: stubAdapter,
+        }));
 
-          expect(stubAdapter.validateModel).toHaveBeenCalledWith('posts', {
-            dispatch: jasmine.any(Function),
-            getState: jasmine.any(Function),
-            validateOptions,
-          });
+        expect(stubAdapter.validateModel).toHaveBeenCalledWith('posts', attributes, {
+          dispatch: jasmine.any(Function),
+          getState: jasmine.any(Function),
+          validateOptions,
         });
       });
     });

--- a/spec/actions/model-spec.js
+++ b/spec/actions/model-spec.js
@@ -177,7 +177,7 @@ describe('model action creators', () => {
           dispatch: jasmine.any(Function),
           getState: jasmine.any(Function),
           fetchOptions,
-         });
+        });
       });
     });
 
@@ -227,7 +227,7 @@ describe('model action creators', () => {
             dispatch: jasmine.any(Function),
             getState: jasmine.any(Function),
             destroyOptions,
-           });
+          });
         });
       });
     });
@@ -253,7 +253,7 @@ describe('model action creators', () => {
             dispatch: jasmine.any(Function),
             getState: jasmine.any(Function),
             validateOptions,
-           });
+          });
         });
       });
     });

--- a/spec/reducers/sync-collections-spec.js
+++ b/spec/reducers/sync-collections-spec.js
@@ -1,0 +1,24 @@
+const syncCollections = require('../../lib/reducers/sync-collections.js');
+
+describe('syncCollections', () => {
+  const initialState = { users: { 1: 'user1', 2: 'user2' } };
+  const collectionsToMerge = {
+    users: { 2: 'user20', 3: 'user3' },
+    workspaces: { 1: 'w1', 2: 'w1' },
+    roles: {},
+  };
+
+  it('merges collections into the state', () => {
+    const action = {
+      payload: {
+        collections: collectionsToMerge,
+      },
+    };
+    const expectedCollections = {
+      users: { 1: 'user1', 2: 'user20', 3: 'user3' },
+      workspaces: { 1: 'w1', 2: 'w1' },
+      roles: {},
+    };
+    expect(syncCollections(initialState, action)).toEqual(expectedCollections);
+  });
+});

--- a/spec/types/make-brainstem-type-spec.js
+++ b/spec/types/make-brainstem-type-spec.js
@@ -114,9 +114,19 @@ describe('makeBrainstemType', () => {
     });
 
     it('forwards the request to brainstem-redux', () => {
-      const options = 'OPTIONS';
-      expect(type.fetchAll(options)).toEqual('RESULT');
-      expect(collectionActions.fetch).toHaveBeenCalledWith(brainstemKey, options);
+      expect(type.fetchAll({ stuff: 'options' })).toEqual('RESULT');
+      expect(collectionActions.fetch).toHaveBeenCalledWith(brainstemKey, { stuff: 'options', adapter: undefined });
+    });
+
+    describe('passing in adapter', () => {
+      it('appends the adapter to the options', () => {
+        const typeWithAdapter = makeBrainstemType(brainstemKey, {
+          adapter: 'adapter',
+        });
+
+        expect(typeWithAdapter.fetchAll({ foo: 'test' })).toEqual('RESULT');
+        expect(collectionActions.fetch).toHaveBeenCalledWith(brainstemKey, { foo: 'test', adapter: 'adapter' });
+      });
     });
   });
 

--- a/spec/types/make-brainstem-type-spec.js
+++ b/spec/types/make-brainstem-type-spec.js
@@ -142,6 +142,17 @@ describe('makeBrainstemType', () => {
       expect(type.fetch(id, options)).toEqual('RESULT');
       expect(modelActions.fetch).toHaveBeenCalledWith(brainstemKey, id, options);
     });
+
+    describe('passing in adapter', () => {
+      it('appends the adapter to the options', () => {
+        const typeWithAdapter = makeBrainstemType(brainstemKey, {
+          adapter: 'adapter',
+        });
+
+        expect(typeWithAdapter.fetch(1, { foo: 'test' })).toEqual('RESULT');
+        expect(modelActions.fetch).toHaveBeenCalledWith(brainstemKey, 1, { foo: 'test', adapter: 'adapter' });
+      });
+    });
   });
 
   describe('saving a model', () => {
@@ -156,6 +167,17 @@ describe('makeBrainstemType', () => {
       expect(type.save(id, attributes, options)).toEqual('RESULT');
       expect(modelActions.save).toHaveBeenCalledWith(brainstemKey, id, attributes, options);
     });
+
+    describe('passing in adapter', () => {
+      it('appends the adapter to the options', () => {
+        const typeWithAdapter = makeBrainstemType(brainstemKey, {
+          adapter: 'adapter',
+        });
+
+        expect(typeWithAdapter.save(1, {}, { foo: 'test' })).toEqual('RESULT');
+        expect(modelActions.save).toHaveBeenCalledWith(brainstemKey, 1, {}, { foo: 'test', adapter: 'adapter' });
+      });
+    });
   });
 
   describe('deleting a model', () => {
@@ -168,6 +190,17 @@ describe('makeBrainstemType', () => {
       const options = 'OPTIONS';
       expect(type.destroy(id, options)).toEqual('RESULT');
       expect(modelActions.destroy).toHaveBeenCalledWith(brainstemKey, id, options);
+    });
+
+    describe('passing in adapter', () => {
+      it('appends the adapter to the options', () => {
+        const typeWithAdapter = makeBrainstemType(brainstemKey, {
+          adapter: 'adapter',
+        });
+
+        expect(typeWithAdapter.destroy(1, { foo: 'test' })).toEqual('RESULT');
+        expect(modelActions.destroy).toHaveBeenCalledWith(brainstemKey, 1, { foo: 'test', adapter: 'adapter' });
+      });
     });
   });
 

--- a/spec/types/make-brainstem-type-spec.js
+++ b/spec/types/make-brainstem-type-spec.js
@@ -220,10 +220,11 @@ describe('makeBrainstemType', () => {
     });
 
     describe('when the origin is not the brainstem storage manager', () => {
-      const action = {
-        ...modelAction,
-        meta: { origin: 'OTHER' },
-      };
+      const action = Object.assign(
+        {},
+        modelAction,
+        { meta: { origin: 'OTHER' } },
+      );
 
       it('does not match', () => {
         itDoesNotMatch(action);
@@ -239,7 +240,11 @@ describe('makeBrainstemType', () => {
     });
 
     describe('when the action is for a different model', () => {
-      const action = { ...modelAction, payload: { brainstemKey: 'OTHER_KEY' } };
+      const action = Object.assign(
+        {},
+        modelAction,
+        { payload: { brainstemKey: 'OTHER_KEY' } },
+      );
 
       it('does not match', () => {
         itDoesNotMatch(action);
@@ -247,7 +252,11 @@ describe('makeBrainstemType', () => {
     });
 
     describe('when there is no brainstem key', () => {
-      const action = { ...modelAction, payload: {} };
+      const action = Object.assign(
+        {},
+        modelAction,
+        { payload: {} },
+      );
 
       it('does not match', () => {
         itDoesNotMatch(action);

--- a/spec/types/make-brainstem-type-spec.js
+++ b/spec/types/make-brainstem-type-spec.js
@@ -26,6 +26,15 @@ describe('makeBrainstemType', () => {
       });
     });
 
+    describe('looking up all models in the state that return true for a filterPredicate passed into options', () => {
+      it('returns all models in the state tree', () => {
+        const typeWithDefaultScope = makeBrainstemType(brainstemKey, {
+          filterPredicate: model => model.id === '5',
+        });
+        expect(typeWithDefaultScope.all(state)).toEqual({ [model1.id]: model1 });
+      });
+    });
+
     describe('finding a model by id', () => {
       describe('when the model is present', () => {
         const id = model2.id;

--- a/spec/types/make-brainstem-type-spec.js
+++ b/spec/types/make-brainstem-type-spec.js
@@ -114,8 +114,9 @@ describe('makeBrainstemType', () => {
     });
 
     it('forwards the request to brainstem-redux', () => {
-      expect(type.fetchAll({ stuff: 'options' })).toEqual('RESULT');
-      expect(collectionActions.fetch).toHaveBeenCalledWith(brainstemKey, { stuff: 'options', adapter: undefined });
+      const options = { stuff: 'options' };
+      expect(type.fetchAll(options)).toEqual('RESULT');
+      expect(collectionActions.fetch).toHaveBeenCalledWith(brainstemKey, options);
     });
 
     describe('passing in adapter', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR includes changes to the model and collection actions present in this repo. Specifically, an "adapter pattern" has been introduced to allow the invoker of the above-mentioned actions to provide an adapter that responds to a standard set of method calls, like `adapter.fetchCollection` or `adapter.saveModel` with the purpose of syncing records with a remote brainstem backend.
Usage of this pattern moves the process of syncing from within these model and collection actions to a given adapter.

The motivation for this change is to allow usage of `brainstem-redux` without the involvement of StorageManager/Backbone. Using Backbone models through StorageManager is a detriment to application performance when a large number of records are loaded into the front-end. This change will allow Mavenlink (or others) to write a custom adapter that bypasses StorageManager and loads many records directly into state.brainstem in a more performant manner.

While this is a substantial change to how `brainstem-redux` _can_ function, all existing functionality provided by this library will be preserved as the default behavior. This is achieved by providing a default adapter to each action that calls the existing StorageManager-specific code. So while it is possible to use a custom adapter, the backbone-centric implementation will continue to the default option, ensuring backwards compatibility.

**Test plan**

This behavior is verified through tests that verify the existing StorageManager-specific code is called when an adapter is not passed in as an option and that a passed in adapter has it's methods called as expected. With the exception of the defaultAdapter that includes storage manager code, we don't care how the adapter implements its syncing, but instead that it responds to calls in the expected ways. Adapters will be responsible for unit testing their syncing functionality. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- Requirement for Mavenlink engineers: Provide links to any related product requirements and builds using this changeset (e.g. mavenlink/mavenlink). -->

**General upkeep checklist**

- [ ] Examples are working
