### PR TITLE
[WIP] Pass through pagination state with collection fetch resolutions

### DIFF
--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -26,7 +26,7 @@ module.exports = {
       if (trackKey) xhrs[trackKey] = xhr;
 
       return new Promise((resolve, reject) => xhr
-        .done(collection => resolve(collection.map(model => model.attributes)))
+        .done(collection => resolve(collection.map(model => model.attributes), collection.state))
         .fail(reject)
       );
     };


### PR DESCRIPTION
WIP WIP WIP WIP WIP WIP WIP

Add pagination state to the `collectionActions.fetch` promise resolution, so that we can know how many pages there are for pagination purposes.