### PR TITLE
Pagination state

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -32,6 +32,7 @@ module.exports = config =>
 
     files: [
       'spec/actions/*.js',
+      'spec/adapters/*.js',
       'spec/reducers/*.js',
       'spec/middleware/*.js',
       'spec/sync/*.js',

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -24,15 +24,15 @@ module.exports = {
       });
 
       if (postFetchAction) {
-        xhr.done(collection =>
-          dispatch(postFetchAction(adapter.extractIds(collection)))
+        xhr.done(response =>
+          dispatch(postFetchAction(adapter.extractIds(response)))
         );
       }
 
       if (trackKey) xhrs[trackKey] = xhr;
 
       return new Promise((resolve, reject) => xhr
-        .done(collection => resolve(adapter.extractPayload(collection, fetchOptions)))
+        .done(response => resolve(adapter.extractPayload(response, fetchOptions)))
         .fail(reject)
       );
     };

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -32,7 +32,7 @@ module.exports = {
       if (trackKey) xhrs[trackKey] = xhr;
 
       return new Promise((resolve, reject) => xhr
-        .done(collection => resolve(adapter.collectionToArray(collection)))
+        .done(collection => resolve(adapter.extractPayload(collection)))
         .fail(reject)
       );
     };

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -25,7 +25,7 @@ module.exports = {
 
       if (postFetchAction) {
         xhr.done(collection =>
-          dispatch(postFetchAction(adapter.collectionToIds(collection)))
+          dispatch(postFetchAction(adapter.extractIds(collection)))
         );
       }
 

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -32,7 +32,7 @@ module.exports = {
       if (trackKey) xhrs[trackKey] = xhr;
 
       return new Promise((resolve, reject) => xhr
-        .done(collection => resolve(adapter.extractPayload(collection)))
+        .done(collection => resolve(adapter.extractPayload(collection, fetchOptions)))
         .fail(reject)
       );
     };

--- a/lib/actions/collection.js
+++ b/lib/actions/collection.js
@@ -32,7 +32,7 @@ module.exports = {
       if (trackKey) xhrs[trackKey] = xhr;
 
       return new Promise((resolve, reject) => xhr
-        .done(response => resolve(adapter.extractPayload(response, fetchOptions)))
+        .done(response => resolve(adapter.extractPayload(response)))
         .fail(reject)
       );
     };

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -28,7 +28,7 @@ module.exports = {
     const Model = storageManager.storage(brainstemKey).model;
     return new Model().validate(attributes, options.validateOptions);
   },
-  collectionToIds: collection => collection.pluck('id'),
+  extractIds: collection => collection.pluck('id'),
   extractPayload(collection) {
     return {
       count: collection.getServerCount(),

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -29,7 +29,7 @@ module.exports = {
     return new Model().validate(attributes, options.validateOptions);
   },
   collectionToIds: collection => collection.pluck('id'),
-  collectionToArray(collection) {
+  extractPayload(collection) {
     return {
       count: collection.getServerCount(),
       currentPage: collection.getPageIndex(),

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -29,6 +29,13 @@ module.exports = {
     return new Model().validate(attributes, options.validateOptions);
   },
   collectionToIds: collection => collection.pluck('id'),
-  collectionToArray: collection => collection.map(model => model.attributes),
+  collectionToArray(collection) {
+    return {
+      count: collection.getServerCount(),
+      currentPage: collection.getPageIndex(),
+      results: collection.map(model => model.attributes),
+      totalPages: collection._maxPage(), // eslint-disable-line no-underscore-dangle
+    };
+  },
   modelToId: model => model.get('id'),
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.36-alpha.1",
+  "version": "0.0.36-alpha.2",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.36-alpha.2",
+  "version": "0.0.36",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.35",
+  "version": "0.0.36-alpha.1",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [

--- a/spec/actions/collection-spec.js
+++ b/spec/actions/collection-spec.js
@@ -26,7 +26,7 @@ describe('collection action creators', () => {
         expect(this.store.dispatch(this.fetch('posts'))).toEqual(jasmine.any(Promise));
       });
 
-      it('resolves with raw attributes when jqXHR is done', function (done) {
+      it('resolves with an object when jqXHR is done', function (done) {
         const postsModels = [new Post({ id: 1, title: 'Bar' }), new Post({ id: 2, title: 'Foo' })];
         const expectation = this.storageManager.stub('posts', {
           response(responseBody) {
@@ -34,7 +34,12 @@ describe('collection action creators', () => {
           },
         });
         this.store.dispatch(this.fetch('posts')).then((response) => {
-          expect(response).toEqual(postsModels.map(model => model.attributes));
+          expect(response).toEqual({
+            count: 2,
+            currentPage: 1,
+            results: postsModels.map(model => model.attributes),
+            totalPages: 1,
+          });
           done();
         });
         expectation.respond();

--- a/spec/adapters/default-spec.js
+++ b/spec/adapters/default-spec.js
@@ -10,10 +10,24 @@ describe('adapters default', () => {
   });
 
   test('collectionToArray', () => {
-    const collection = new Collection([{ foo: 'bar' }, { foo: 'baz' }]);
-    expect(defaultAdapter.collectionToArray(collection)).toEqual([
-      { foo: 'bar' },
-      { foo: 'baz' },
+    const collection = new Collection([
+      { id: 1, foo: 'bar' },
+      { id: 2, foo: 'baz' },
     ]);
+    collection.lastFetchOptions = {
+      page: 2,
+      perPage: 10,
+    };
+    spyOn(collection, '_getCacheObject').and.returnValue({ count: 101 });
+
+    expect(defaultAdapter.collectionToArray(collection)).toEqual({
+      results: [
+        { id: 1, foo: 'bar' },
+        { id: 2, foo: 'baz' },
+      ],
+      count: 101,
+      currentPage: 2,
+      totalPages: 11,
+    });
   });
 });

--- a/spec/adapters/default-spec.js
+++ b/spec/adapters/default-spec.js
@@ -1,15 +1,13 @@
 import { Collection } from 'brainstem-js';
 import defaultAdapter from '../../lib/adapters/default';
 
-const test = it;
-
 describe('adapters default', () => {
-  test('extractIds', () => {
+  it('returns the right result from extractIds', () => {
     const collection = new Collection([{ id: 1 }, { id: 2 }, { id: 3 }]);
     expect(defaultAdapter.extractIds(collection)).toEqual([1, 2, 3]);
   });
 
-  test('extractPayload', () => {
+  it('returns the right result from extractPayload', () => {
     const collection = new Collection([
       { id: 1, foo: 'bar' },
       { id: 2, foo: 'baz' },

--- a/spec/adapters/default-spec.js
+++ b/spec/adapters/default-spec.js
@@ -4,9 +4,9 @@ import defaultAdapter from '../../lib/adapters/default';
 const test = it;
 
 describe('adapters default', () => {
-  test('collectionToIds', () => {
+  test('extractIds', () => {
     const collection = new Collection([{ id: 1 }, { id: 2 }, { id: 3 }]);
-    expect(defaultAdapter.collectionToIds(collection)).toEqual([1, 2, 3]);
+    expect(defaultAdapter.extractIds(collection)).toEqual([1, 2, 3]);
   });
 
   test('extractPayload', () => {

--- a/spec/adapters/default-spec.js
+++ b/spec/adapters/default-spec.js
@@ -1,0 +1,19 @@
+import { Collection } from 'brainstem-js';
+import defaultAdapter from '../../lib/adapters/default';
+
+const test = it;
+
+describe('adapters default', () => {
+  test('collectionToIds', () => {
+    const collection = new Collection([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expect(defaultAdapter.collectionToIds(collection)).toEqual([1, 2, 3]);
+  });
+
+  test('collectionToArray', () => {
+    const collection = new Collection([{ foo: 'bar' }, { foo: 'baz' }]);
+    expect(defaultAdapter.collectionToArray(collection)).toEqual([
+      { foo: 'bar' },
+      { foo: 'baz' },
+    ]);
+  });
+});

--- a/spec/adapters/default-spec.js
+++ b/spec/adapters/default-spec.js
@@ -9,7 +9,7 @@ describe('adapters default', () => {
     expect(defaultAdapter.collectionToIds(collection)).toEqual([1, 2, 3]);
   });
 
-  test('collectionToArray', () => {
+  test('extractPayload', () => {
     const collection = new Collection([
       { id: 1, foo: 'bar' },
       { id: 2, foo: 'baz' },
@@ -20,7 +20,7 @@ describe('adapters default', () => {
     };
     spyOn(collection, '_getCacheObject').and.returnValue({ count: 101 });
 
-    expect(defaultAdapter.collectionToArray(collection)).toEqual({
+    expect(defaultAdapter.extractPayload(collection)).toEqual({
       results: [
         { id: 1, foo: 'bar' },
         { id: 2, foo: 'baz' },


### PR DESCRIPTION
This PR does two things:

- Adds pagination state (current page, total pages, etc) to the promise resolutions of `collectionActions.fetch`
- Refactors the promise resolutions to use a standard object

Please don't merge until we've backfilled Mavenlink to use this updated format.

@bobby1190 @heyellieday can you take a look at this, please?

RFC -> https://github.com/mavenlink/rfc/pull/28
Brainstem -> https://github.com/mavenlink/brainstem/pull/100
Brainstem-js -> https://github.com/mavenlink/brainstem-js/pull/121
Bigmaven PR -> https://github.com/mavenlink/mavenlink/pull/10740