### PR TITLE
Sync Collections Reducer will merge new attributes for each model

### DIFF
--- a/lib/reducers/sync-collections.js
+++ b/lib/reducers/sync-collections.js
@@ -4,11 +4,11 @@ module.exports = (state, action) => {
   const collectionNames = Object.keys(collections);
 
   collectionNames.forEach((collectionName) => {
-    mergedCollections[collectionName] = Object.assign(
-      {},
-      state[collectionName],
-      collections[collectionName],
-    );
+    const newCollection = Object.assign({}, state[collectionName]);
+    Object.keys(collections[collectionName]).forEach((id) => {
+      newCollection[id] = Object.assign({}, newCollection[id], collections[collectionName][id]);
+    });
+    mergedCollections[collectionName] = newCollection;
   });
 
   return Object.assign({}, state, mergedCollections);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.37-alpha.1",
+  "version": "0.0.37",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.0.35",
+  "version": "0.0.37-alpha.1",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [

--- a/spec/reducers/sync-collections-spec.js
+++ b/spec/reducers/sync-collections-spec.js
@@ -1,24 +1,51 @@
 const syncCollections = require('../../lib/reducers/sync-collections.js');
 
 describe('syncCollections', () => {
-  const initialState = { users: { 1: 'user1', 2: 'user2' } };
+  beforeEach(function () {
+    this.initialState = { users: { 1: { name: 'user1' }, 2: { name: 'user2' } } };
+  });
+
   const collectionsToMerge = {
-    users: { 2: 'user20', 3: 'user3' },
-    workspaces: { 1: 'w1', 2: 'w1' },
+    users: { 2: { name: 'user20' }, 3: { name: 'user3' } },
+    workspaces: { 1: { name: 'w1' }, 2: { name: 'w1' } },
     roles: {},
   };
 
-  it('merges collections into the state', () => {
+  it('merges collections into the state', function () {
     const action = {
       payload: {
         collections: collectionsToMerge,
       },
     };
     const expectedCollections = {
-      users: { 1: 'user1', 2: 'user20', 3: 'user3' },
-      workspaces: { 1: 'w1', 2: 'w1' },
+      users: { 1: { name: 'user1' }, 2: { name: 'user20' }, 3: { name: 'user3' } },
+      workspaces: { 1: { name: 'w1' }, 2: { name: 'w1' } },
       roles: {},
     };
-    expect(syncCollections(initialState, action)).toEqual(expectedCollections);
+    expect(syncCollections(this.initialState, action)).toEqual(expectedCollections);
+  });
+
+  describe('when there are existing models in the collection', () => {
+    beforeEach(function () {
+      this.initialState = { users: { 1: { id: 1, oldAttribute: 'foo', newAttribute: 'bar' } } };
+    });
+
+    it('merges the new attributes onto the models', function () {
+      const action = {
+        payload: {
+          collections: {
+            users: {
+              1: { id: 1, newAttribute: 'baz' },
+            },
+          },
+        },
+      };
+
+      const expectedCollections = {
+        users: { 1: { id: 1, oldAttribute: 'foo', newAttribute: 'baz' } },
+      };
+
+      expect(syncCollections(this.initialState, action)).toEqual(expectedCollections);
+    });
   });
 });


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

- If we were refetching a collection, and our results omitted attributes our
  models already had, we were overriding the entire model and removing
  those attributes. This is not how the default Brainstem adapter behaves.

  Now, we iterate over each model in the result collection and merge on the
  new attributes with the existing models.

<!-- Requirement for Mavenlink engineers: Provide links to any related product requirements and builds using this changeset (e.g. mavenlink/mavenlink). -->
https://github.com/mavenlink/mavenlink/pull/10632

**General upkeep checklist**

- [ ] Examples are working
