### PR TITLE
Avoid using `.all` in `.findInState`

### DIFF
--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -41,7 +41,8 @@ module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultT
     },
 
     findInState(id, state) {
-      return typeFunctions.find(id, state.brainstem[brainstemKey]);
+      const models = mergedOptions.filterPredicate() !== true ? typeFunctions.all(state) : state.brainstem[brainstemKey]
+      return typeFunctions.find(id, models);
     },
 
     fetchAll(options) {

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -41,7 +41,7 @@ module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultT
     },
 
     findInState(id, state) {
-      return typeFunctions.find(id, typeFunctions.all(state));
+      return typeFunctions.find(id, state.brainstem[brainstemKey]);
     },
 
     fetchAll(options) {

--- a/lib/types/make-brainstem-type.js
+++ b/lib/types/make-brainstem-type.js
@@ -14,90 +14,78 @@ module.exports = function makeBrainstemType(brainstemKey, typeOptions = defaultT
     return adapter ? Object.assign({}, options, { adapter }) : options;
   };
 
-  function all(state) {
-    return Object.keys(state.brainstem[brainstemKey])
-      .filter(id => mergedOptions.filterPredicate(state.brainstem[brainstemKey][id]))
-      .reduce((memo, id) => {
-        memo[id] = state.brainstem[brainstemKey][id]; // eslint-disable-line no-param-reassign
-        return memo;
-      }, {});
-  }
+  const typeFunctions = {
+    all(state) {
+      return Object.keys(state.brainstem[brainstemKey])
+        .filter(id => mergedOptions.filterPredicate(state.brainstem[brainstemKey][id]))
+        .reduce((memo, id) => {
+          memo[id] = state.brainstem[brainstemKey][id]; // eslint-disable-line no-param-reassign
+          return memo;
+        }, {});
+    },
 
-  function find(id, models) {
-    return models[id];
-  }
+    find(id, models) {
+      return models[id];
+    },
 
-  function findAll(idList, models) {
-    return idList.map(id => find(id, models));
-  }
+    findAll(idList, models) {
+      return idList.map(id => typeFunctions.find(id, models));
+    },
 
-  function findAllInState(idList, state) {
-    return findAll(idList, all(state));
-  }
+    findAllInState(idList, state) {
+      return typeFunctions.findAll(idList, typeFunctions.all(state));
+    },
 
-  function findInList(id, list) {
-    return list.filter(model => model.id === id)[0];
-  }
+    findInList(id, list) {
+      return list.filter(model => model.id === id)[0];
+    },
 
-  function findInState(id, state) {
-    return find(id, all(state));
-  }
+    findInState(id, state) {
+      return typeFunctions.find(id, typeFunctions.all(state));
+    },
 
-  function fetchAll(options) {
-    return collectionActions.fetch(brainstemKey, buildActionOptions(options));
-  }
+    fetchAll(options) {
+      return collectionActions.fetch(brainstemKey, buildActionOptions(options));
+    },
 
-  function fetch(id, options) {
-    return modelActions.fetch(brainstemKey, id, buildActionOptions(options));
-  }
+    fetch(id, options) {
+      return modelActions.fetch(brainstemKey, id, buildActionOptions(options));
+    },
 
-  function save(id, attributes, options) {
-    return modelActions.save(brainstemKey, id, attributes, buildActionOptions(options));
-  }
+    save(id, attributes, options) {
+      return modelActions.save(brainstemKey, id, attributes, buildActionOptions(options));
+    },
 
-  function destroy(id, options) {
-    return modelActions.destroy(brainstemKey, id, buildActionOptions(options));
-  }
+    destroy(id, options) {
+      return modelActions.destroy(brainstemKey, id, buildActionOptions(options));
+    },
 
-  function matchesAction({ meta, payload }) {
-    return (
-      isObject(meta) && meta.origin === 'storageManager' &&
-      isObject(payload) && payload.brainstemKey === brainstemKey
-    );
-  }
+    matchesAction({ meta, payload }) {
+      return (
+        isObject(meta) && meta.origin === 'storageManager' &&
+        isObject(payload) && payload.brainstemKey === brainstemKey
+      );
+    },
 
-  function modelAction(type, model) {
-    return {
-      type,
-      meta: { origin: 'storageManager' },
-      payload: {
-        brainstemKey,
-        attributes: model,
-      },
-    };
-  }
+    modelAction(type, model) {
+      return {
+        type,
+        meta: { origin: 'storageManager' },
+        payload: {
+          brainstemKey,
+          attributes: model,
+        },
+      };
+    },
 
-  function removeModel(model) {
-    return modelAction('REMOVE_MODEL', model);
-  }
+    removeModel(model) {
+      return typeFunctions.modelAction('REMOVE_MODEL', model);
+    },
 
-  function syncModel(model) {
-    return modelAction('SYNC_MODEL', model);
-  }
-
-  return {
-    all,
-    destroy,
-    find,
-    findAll,
-    findAllInState,
-    findInList,
-    findInState,
-    fetchAll,
-    fetch,
-    matchesAction,
-    removeModel,
-    save,
-    syncModel,
+    syncModel(model) {
+      return typeFunctions.modelAction('SYNC_MODEL', model);
+    },
   };
+
+  return typeFunctions;
 };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,14 @@
     {
       "name": "Ellie Day",
       "email": "eday@mavenlink.com"
+    },
+    {
+      "name": "CM Liotta",
+      "email": "cmliotta@mavenlink.com"
+    },
+    {
+      "name": "Jason Carter",
+      "email": "jason@mavenlink.com"
     }
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstem-redux",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha.1",
   "description": "Client-side Brainstem store in Redux",
   "main": "bin/index.js",
   "files": [

--- a/spec/types/make-brainstem-type-spec.js
+++ b/spec/types/make-brainstem-type-spec.js
@@ -59,6 +59,12 @@ describe('makeBrainstemType', () => {
       it('returns the model', () => {
         expect(type.findInState(id, state)).toEqual(model3);
       });
+
+      it('does not call .all', () => {
+        spyOn(type, 'all').and.callThrough();
+        type.findInState(id, state);
+        expect(type.all).not.toHaveBeenCalled();
+      });
     });
 
     describe('finding a model by id in a list', () => {

--- a/spec/types/make-brainstem-type-spec.js
+++ b/spec/types/make-brainstem-type-spec.js
@@ -65,6 +65,20 @@ describe('makeBrainstemType', () => {
         type.findInState(id, state);
         expect(type.all).not.toHaveBeenCalled();
       });
+
+      describe('with filterPredicate', () => {
+        const typeWithFilterPredicate = makeBrainstemType(brainstemKey, { filterPredicate: thing => thing })
+
+        it('returns the model', () => {
+          expect(typeWithFilterPredicate.findInState(id, state)).toEqual(model3);
+        });
+
+        it('calls .all', () => {
+          spyOn(typeWithFilterPredicate, 'all').and.callThrough();
+          typeWithFilterPredicate.findInState(id, state);
+          expect(typeWithFilterPredicate.all).toHaveBeenCalled();
+        });
+      });
     });
 
     describe('finding a model by id in a list', () => {


### PR DESCRIPTION
**Summary**
As we've been using the library, we've noticed that `.all` can be slow for large collections, and it is much quicker to access the brainstem state directly. We've made the change from:

```javascript
const mapStateToProps = (state, { userId }) => {
    return {
      user: User.findInState(userId, state),
    };
  };
```

 to: 

```javascript
const mapStateToProps = (state, { userId }) => {
    return {
      user: state.brainstem.visual_master_planning_users[userId],
    };
  };
```

often enough in our implementations, that we thought it best to make that change in brainstem-redux. This gives us some performance boosts.

**Test plan**

We published an alpha, we're going to point Bigmaven to it and run our acceptance tests.
