### PR TITLE
Upgrade CI to 2.1 and a few tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,19 +11,19 @@ jobs:
     executor:
       docker:
         - image: circleci/node:8-browsers
-     working_directory: ~/repo
-     steps:
+    working_directory: ~/repo
+    steps:
       - checkout
       - restore_cache:
           keys:
-          - v1-dep-{{ .Branch }}-
-          - v1-dep-master-
-          - v1-dep-
+            - v1-dep-{{ .Branch }}-
+            - v1-dep-master-
+            - v1-dep-
       - run: mkdir -p ~/.cache/yarn
       - run: yarn install
       - save_cache:
           key: v1-dep-{{ .Branch }}-{{ epoch }}
           paths:
-          - ~/.cache/yarn
-          - ./node_modules
+            - ~/.cache/yarn
+            - ./node_modules
       - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,29 @@
-version: 2
+version: 2.1
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - build_and_test
+
 jobs:
-  build:
-    working_directory: ~/mavenlink/brainstem-redux
-    parallelism: 1
-    shell: /bin/bash --login
-    environment:
-      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-    docker:
-    - image: circleci/node:8-browsers
-      command: /sbin/init
-    steps:
-    - checkout
-    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    - restore_cache:
-        keys:
-        - v1-dep-{{ .Branch }}-
-        - v1-dep-master-
-        - v1-dep-
-    - run: mkdir -p ~/.cache/yarn
-    - run: yarn install
-    - save_cache:
-        key: v1-dep-{{ .Branch }}-{{ epoch }}
-        paths:
-        - ~/.cache/yarn
-        - ./node_modules
-    - run: yarn test
-    - store_test_results:
-        path: /tmp/circleci-test-results
-    - store_artifacts:
-        path: /tmp/circleci-artifacts
-    - store_artifacts:
-        path: yarn-error.log
-    - store_artifacts:
-        path: /tmp/circleci-test-results
+  build_and_test:
+    executor:
+      docker:
+        - image: circleci/node:8-browsers
+     working_directory: ~/repo
+     steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dep-{{ .Branch }}-
+          - v1-dep-master-
+          - v1-dep-
+      - run: mkdir -p ~/.cache/yarn
+      - run: yarn install
+      - save_cache:
+          key: v1-dep-{{ .Branch }}-{{ epoch }}
+          paths:
+          - ~/.cache/yarn
+          - ./node_modules
+      - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,8 @@ workflows:
 
 jobs:
   build_and_test:
-    executor:
-      docker:
-        - image: circleci/node:8-browsers
+    docker:
+      - image: circleci/node:8-browsers
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
Looks like CI is failing -- even on `master`. 

This probably has to do with some CI configuration -- either our own or perhaps new updates to the actual containers. 

I am hoping to get stable green builds with the current code in `master`. 