### PR TITLE
Fix example: use new ES6 modules

### DIFF
--- a/example/containers/all-posts-autocomplete-box.js
+++ b/example/containers/all-posts-autocomplete-box.js
@@ -1,7 +1,7 @@
 const { connect } = require('react-redux');
 const PostAutocompleteBox = require('../components/post-autocomplete-box');
 
-const { fetch: fetchCollection } = require('../../lib/actions/collection');
+const { fetch: fetchCollection } = require('../../lib/actions/collection').default;
 const actionCreators = require('../actions/posts-autocompleter');
 
 const mapStateToProps = (state) => {

--- a/example/index.js
+++ b/example/index.js
@@ -10,7 +10,7 @@ const {
 } = require('redux');
 
 const thunkMiddleware = require('redux-thunk').default;
-const syncBrainstemMiddleware = require('../lib/middleware/update-storage-manager');
+const syncBrainstemMiddleware = require('../lib/middleware/update-storage-manager').default;
 const loggerMiddleware = require('./middleware/logger');
 
 const Post = require('./models/post');
@@ -23,7 +23,7 @@ storageManager.addCollection('users', Users);
 
 const store = createStore(
   combineReducers({
-    brainstem: require('../lib/reducers/index'),
+    brainstem: require('../lib/reducers/index').default,
     postsAutocompleter: require('./reducers/posts-autocompleter'),
   }),
   applyMiddleware(
@@ -34,7 +34,7 @@ const store = createStore(
 );
 
 // Transforms a storage manager backbone event into a (dispatched) redux brainstem action
-require('../lib/sync/update-store')(store);
+require('../lib/sync/update-store').default(store);
 
 const posts = storageManager.storage('posts');
 posts.add({ id: 1, title: 'What is redux?', message: 'I do not know but it might be awesome' });


### PR DESCRIPTION
This got broken in a previous PR: https://github.com/mavenlink/brainstem-redux/pull/61

Looks like we updated the library but never the example. We need to figure out a good smoke test for the examples -- this is captured in [our roadmap](https://www.pivotaltracker.com/story/show/166457840).