### PR TITLE
During collections sync, allow conditional behavior to populate state…

### DIFF
--- a/lib/reducers/sync-collections.js
+++ b/lib/reducers/sync-collections.js
@@ -1,10 +1,10 @@
 export default (state, action) => {
   const mergedCollections = {};
-  const { collections } = action.payload;
+  const { collections, preserveRemovedModels = true } = action.payload;
   const collectionNames = Object.keys(collections);
 
   collectionNames.forEach((collectionName) => {
-    const newCollection = Object.assign({}, state[collectionName]);
+    const newCollection = Object.assign({}, preserveRemovedModels ? state[collectionName] : {});
     Object.keys(collections[collectionName]).forEach((id) => {
       newCollection[id] = Object.assign({}, newCollection[id], collections[collectionName][id]);
     });

--- a/spec/reducers/sync-collections-spec.js
+++ b/spec/reducers/sync-collections-spec.js
@@ -15,10 +15,26 @@ describe('syncCollections', () => {
     const action = {
       payload: {
         collections: collectionsToMerge,
+        preserveRemovedModels: true,
       },
     };
     const expectedCollections = {
       users: { 1: { name: 'user1' }, 2: { name: 'user20' }, 3: { name: 'user3' } },
+      workspaces: { 1: { name: 'w1' }, 2: { name: 'w1' } },
+      roles: {},
+    };
+    expect(syncCollections(this.initialState, action)).toEqual(expectedCollections);
+  });
+
+  it('merges new collection models into the state, and prunes removed models', function () {
+    const action = {
+      payload: {
+        collections: collectionsToMerge,
+        preserveRemovedModels: false,
+      },
+    };
+    const expectedCollections = {
+      users: { 2: { name: 'user20' }, 3: { name: 'user3' } },
       workspaces: { 1: { name: 'w1' }, 2: { name: 'w1' } },
       roles: {},
     };
@@ -38,6 +54,7 @@ describe('syncCollections', () => {
               1: { id: 1, newAttribute: 'baz' },
             },
           },
+          preserveRemovedModels: true,
         },
       };
 


### PR DESCRIPTION
**Summary**

During collections sync, allow conditional behavior to populate state exactly as retrieved from API vs. merging in new models into existing state.

Reasoning being that the DB could have been modified outside the scope of the current window, either by another user or API integration. In these cases, if we are refetching data from brainstem we want to remove deleted models from the collection.

Specifically this change in behavior is to address this customer issue: https://www.pivotaltracker.com/n/projects/407849/stories/174270726

**Test plan**

Added an automated test around the new flag.