### PR TITLE
Upgrade underscore from 1.8.3 to 1.13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-redux": "^5.0.6",
     "redux": "^4.0.4",
     "redux-thunk": "^2.1.0",
-    "underscore": ">= 1.4.4",
+    "underscore": "^1.13.6",
     "webpack": "3.11.0",
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-dev-server": "2.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5153,9 +5153,10 @@ uglifyjs-webpack-plugin@^0.4.6:
     uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
 
-"underscore@>= 1.4.4", underscore@>=1.5.0:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+underscore@>=1.5.0, underscore@^1.13.6:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
Upgrade `underscore` to address CVE: https://github.com/mavenlink/brainstem-redux/security/dependabot/40